### PR TITLE
♻️ コードコメントのリファクタリング

### DIFF
--- a/src/converter/elements/image/img-element/img-element.ts
+++ b/src/converter/elements/image/img-element/img-element.ts
@@ -108,7 +108,6 @@ export const ImgElement = {
       return [Paint.image(src!)];
     }
     
-    // プレースホルダー
     return [Paint.solid(DEFAULT_PLACEHOLDER_COLOR)];
   },
 


### PR DESCRIPTION
## 概要
コメントレビューエージェントで指摘された不要なコメントを削除し、コードの可読性を向上させました。

## 変更内容

### 🧹 削除したコメント
- **mapper.ts**: 自明なコメント約50件を削除
  - 「デフォルトのスペーシング値」
  - 「オプションを正規化」
  - 「テキストノードの場合」
  - 「要素ノードの場合」など

- **img-element.ts**: プレースホルダーの不要なコメントを削除

### ♻️ 改善したコメント
- 曖昧な実装コメントを具体的なTODOコメントに変更
  - `実際のFigma APIでは異なる実装が必要` → `TODO: Figma APIのfontName実装を追加`
  - `実際のFigma APIでは異なる処理が必要` → `TODO: marginを親要素のAuto Layoutとして処理する実装を追加`

## 影響範囲
- src/converter/mapper.ts
- src/converter/elements/image/img-element/img-element.ts

## テスト
- [x] 既存のテストが通ることを確認
- [x] コメント削除による機能への影響がないことを確認

## レビューポイント
- コメント削除が適切かどうか
- TODOコメントの記載内容が明確かどうか

## 関連Issue
なし