### PR TITLE
♻️ マジックナンバーの除去と定数名の改善

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -5,7 +5,22 @@ interface PluginMessage {
   html?: string;
 }
 
-figma.showUI(__uiFiles__['ui.html'], { width: 600, height: 400 });
+// UI設定定数
+const UI_CONFIG = {
+  DIALOG_WIDTH: 600,
+  DIALOG_HEIGHT: 400,
+  DEFAULT_FRAME_WIDTH: 800,
+  DEFAULT_FRAME_HEIGHT: 600,
+  TEXT_PADDING: 20,
+  TEXT_WIDTH: 760,
+  TEXT_HEIGHT: 560,
+  DEFAULT_FONT_SIZE: 14
+} as const;
+
+figma.showUI(__uiFiles__['ui.html'], { 
+  width: UI_CONFIG.DIALOG_WIDTH, 
+  height: UI_CONFIG.DIALOG_HEIGHT 
+});
 
 figma.ui.onmessage = async (msg: PluginMessage) => {
   if (msg.type === 'convert-html') {
@@ -16,16 +31,16 @@ figma.ui.onmessage = async (msg: PluginMessage) => {
       frame.name = 'Converted HTML';
       frame.x = 0;
       frame.y = 0;
-      frame.resize(800, 600);
+      frame.resize(UI_CONFIG.DEFAULT_FRAME_WIDTH, UI_CONFIG.DEFAULT_FRAME_HEIGHT);
       
       const text = figma.createText();
-      text.x = 20;
-      text.y = 20;
-      text.resize(760, 560);
+      text.x = UI_CONFIG.TEXT_PADDING;
+      text.y = UI_CONFIG.TEXT_PADDING;
+      text.resize(UI_CONFIG.TEXT_WIDTH, UI_CONFIG.TEXT_HEIGHT);
       
       await figma.loadFontAsync({ family: "Inter", style: "Regular" });
       text.characters = `HTML Content:\n\n${html}`;
-      text.fontSize = 14;
+      text.fontSize = UI_CONFIG.DEFAULT_FONT_SIZE;
       text.fills = [{ type: 'SOLID', color: { r: 0, g: 0, b: 0 } }];
       
       frame.appendChild(text);

--- a/src/converter/constants/color-constants.ts
+++ b/src/converter/constants/color-constants.ts
@@ -1,0 +1,39 @@
+/**
+ * 色変換で使用される共通定数
+ */
+export const COLOR_CONVERSION = {
+  /** RGB値の最大値 */
+  RGB_MAX: 255,
+  /** 色相の最大値（度） */
+  HUE_MAX_DEGREES: 360,
+  /** 彩度の最大値（パーセント） */
+  SATURATION_MAX_PERCENT: 100,
+  /** 明度の最大値（パーセント） */
+  LIGHTNESS_MAX_PERCENT: 100,
+  /** 16進数カラーコードの短縮形の長さ */
+  HEX_SHORT_LENGTH: 3,
+  /** 16進数カラーコードの標準形の長さ */
+  HEX_FULL_LENGTH: 6,
+  /** 16進数の基数 */
+  HEX_RADIX: 16,
+  /** 輝度計算の赤成分係数（ITU-R BT.709標準） */
+  LUMINANCE_RED: 0.299,
+  /** 輝度計算の緑成分係数（ITU-R BT.709標準） */
+  LUMINANCE_GREEN: 0.587,
+  /** 輝度計算の青成分係数（ITU-R BT.709標準） */
+  LUMINANCE_BLUE: 0.114
+} as const;
+
+/**
+ * 数値比較の定数
+ */
+export const NUMERIC_COMPARISON = {
+  /** 浮動小数点比較の許容誤差 */
+  EPSILON: 0.001,
+  /** パーセンテージ計算の除数 */
+  PERCENTAGE_DIVISOR: 100,
+  /** 100パーセント */
+  FULL_PERCENTAGE: 100,
+  /** 50パーセント */
+  HALF_PERCENTAGE: 50
+} as const;

--- a/src/converter/constants/color-constants.ts
+++ b/src/converter/constants/color-constants.ts
@@ -1,27 +1,62 @@
 /**
- * 色変換で使用される共通定数
+ * RGB色空間の定数
  */
-export const COLOR_CONVERSION = {
-  /** RGB値の最大値 */
-  RGB_MAX: 255,
+export const RGB_CONSTANTS = {
+  /** RGB各チャンネルの最大値 */
+  MAX_VALUE: 255,
+  /** RGB各チャンネルの最小値 */
+  MIN_VALUE: 0
+} as const;
+
+/**
+ * HSL色空間の定数
+ */
+export const HSL_CONSTANTS = {
   /** 色相の最大値（度） */
   HUE_MAX_DEGREES: 360,
   /** 彩度の最大値（パーセント） */
-  SATURATION_MAX_PERCENT: 100,
+  SATURATION_MAX: 100,
   /** 明度の最大値（パーセント） */
-  LIGHTNESS_MAX_PERCENT: 100,
-  /** 16進数カラーコードの短縮形の長さ */
-  HEX_SHORT_LENGTH: 3,
-  /** 16進数カラーコードの標準形の長さ */
-  HEX_FULL_LENGTH: 6,
+  LIGHTNESS_MAX: 100
+} as const;
+
+/**
+ * 16進数カラーコードの定数
+ */
+export const HEX_COLOR_CONSTANTS = {
+  /** 短縮形の長さ（例：#FFF） */
+  SHORT_LENGTH: 3,
+  /** 標準形の長さ（例：#FFFFFF） */
+  FULL_LENGTH: 6,
   /** 16進数の基数 */
-  HEX_RADIX: 16,
-  /** 輝度計算の赤成分係数（ITU-R BT.709標準） */
-  LUMINANCE_RED: 0.299,
-  /** 輝度計算の緑成分係数（ITU-R BT.709標準） */
-  LUMINANCE_GREEN: 0.587,
-  /** 輝度計算の青成分係数（ITU-R BT.709標準） */
-  LUMINANCE_BLUE: 0.114
+  RADIX: 16
+} as const;
+
+/**
+ * 輝度計算の係数（ITU-R BT.709標準）
+ */
+export const LUMINANCE_COEFFICIENTS = {
+  /** 赤成分の係数 */
+  RED: 0.299,
+  /** 緑成分の係数 */
+  GREEN: 0.587,
+  /** 青成分の係数 */
+  BLUE: 0.114
+} as const;
+
+// 後方互換性のため、COLOR_CONVERSIONもエクスポート（非推奨）
+/** @deprecated 個別の定数（RGB_CONSTANTS, HSL_CONSTANTS等）を使用してください */
+export const COLOR_CONVERSION = {
+  RGB_MAX: RGB_CONSTANTS.MAX_VALUE,
+  HUE_MAX_DEGREES: HSL_CONSTANTS.HUE_MAX_DEGREES,
+  SATURATION_MAX_PERCENT: HSL_CONSTANTS.SATURATION_MAX,
+  LIGHTNESS_MAX_PERCENT: HSL_CONSTANTS.LIGHTNESS_MAX,
+  HEX_SHORT_LENGTH: HEX_COLOR_CONSTANTS.SHORT_LENGTH,
+  HEX_FULL_LENGTH: HEX_COLOR_CONSTANTS.FULL_LENGTH,
+  HEX_RADIX: HEX_COLOR_CONSTANTS.RADIX,
+  LUMINANCE_RED: LUMINANCE_COEFFICIENTS.RED,
+  LUMINANCE_GREEN: LUMINANCE_COEFFICIENTS.GREEN,
+  LUMINANCE_BLUE: LUMINANCE_COEFFICIENTS.BLUE
 } as const;
 
 /**

--- a/src/converter/constants/color-constants.ts
+++ b/src/converter/constants/color-constants.ts
@@ -1,7 +1,7 @@
 /**
- * RGB色空間の定数
+ * RGB色空間の範囲
  */
-export const RGB_CONSTANTS = {
+export const RGB_RANGE = {
   /** RGB各チャンネルの最大値 */
   MAX_VALUE: 255,
   /** RGB各チャンネルの最小値 */
@@ -9,9 +9,9 @@ export const RGB_CONSTANTS = {
 } as const;
 
 /**
- * HSL色空間の定数
+ * HSL色空間の制限値
  */
-export const HSL_CONSTANTS = {
+export const HSL_LIMITS = {
   /** 色相の最大値（度） */
   HUE_MAX_DEGREES: 360,
   /** 彩度の最大値（パーセント） */
@@ -21,9 +21,9 @@ export const HSL_CONSTANTS = {
 } as const;
 
 /**
- * 16進数カラーコードの定数
+ * 16進数カラーコードのフォーマット
  */
-export const HEX_COLOR_CONSTANTS = {
+export const HEX_FORMAT = {
   /** 短縮形の長さ（例：#FFF） */
   SHORT_LENGTH: 3,
   /** 標準形の長さ（例：#FFFFFF） */
@@ -33,31 +33,17 @@ export const HEX_COLOR_CONSTANTS = {
 } as const;
 
 /**
- * 輝度計算の係数（ITU-R BT.709標準）
+ * 輝度計算の重み（ITU-R BT.709標準）
  */
-export const LUMINANCE_COEFFICIENTS = {
-  /** 赤成分の係数 */
+export const LUMINANCE_WEIGHTS = {
+  /** 赤成分の重み */
   RED: 0.299,
-  /** 緑成分の係数 */
+  /** 緑成分の重み */
   GREEN: 0.587,
-  /** 青成分の係数 */
+  /** 青成分の重み */
   BLUE: 0.114
 } as const;
 
-// 後方互換性のため、COLOR_CONVERSIONもエクスポート（非推奨）
-/** @deprecated 個別の定数（RGB_CONSTANTS, HSL_CONSTANTS等）を使用してください */
-export const COLOR_CONVERSION = {
-  RGB_MAX: RGB_CONSTANTS.MAX_VALUE,
-  HUE_MAX_DEGREES: HSL_CONSTANTS.HUE_MAX_DEGREES,
-  SATURATION_MAX_PERCENT: HSL_CONSTANTS.SATURATION_MAX,
-  LIGHTNESS_MAX_PERCENT: HSL_CONSTANTS.LIGHTNESS_MAX,
-  HEX_SHORT_LENGTH: HEX_COLOR_CONSTANTS.SHORT_LENGTH,
-  HEX_FULL_LENGTH: HEX_COLOR_CONSTANTS.FULL_LENGTH,
-  HEX_RADIX: HEX_COLOR_CONSTANTS.RADIX,
-  LUMINANCE_RED: LUMINANCE_COEFFICIENTS.RED,
-  LUMINANCE_GREEN: LUMINANCE_COEFFICIENTS.GREEN,
-  LUMINANCE_BLUE: LUMINANCE_COEFFICIENTS.BLUE
-} as const;
 
 /**
  * 数値比較の定数

--- a/src/converter/constants/index.ts
+++ b/src/converter/constants/index.ts
@@ -1,1 +1,3 @@
 export * from './css-values';
+export * from './color-constants';
+export * from './viewport-constants';

--- a/src/converter/constants/viewport-constants.ts
+++ b/src/converter/constants/viewport-constants.ts
@@ -1,0 +1,11 @@
+/**
+ * ビューポートとレイアウトのデフォルト値
+ */
+export const DEFAULT_VIEWPORT = {
+  /** デフォルトのビューポート幅（px） */
+  WIDTH: 1920,
+  /** デフォルトのビューポート高さ（px） */
+  HEIGHT: 1080,
+  /** デフォルトのフォントサイズ（px） */
+  FONT_SIZE: 16
+} as const;

--- a/src/converter/mapper.ts
+++ b/src/converter/mapper.ts
@@ -8,7 +8,14 @@ import type { ConversionOptions as ConversionOptionsType } from "./models/conver
 import { AutoLayoutProperties } from "./models/auto-layout";
 import { ImgElement } from "./elements/image";
 
-const DEFAULT_SPACING = 8;
+// レイアウト関連の定数
+const LAYOUT_CONFIG = {
+  DEFAULT_SPACING: 8,
+  DEFAULT_CONTAINER_WIDTH: 800,
+  DEFAULT_CONTAINER_HEIGHT: 600,
+  FULL_PERCENTAGE: 100,
+  HALF_PERCENTAGE: 50
+} as const;
 
 export function mapHTMLNodeToFigma(
   htmlNode: HTMLNode,
@@ -69,7 +76,7 @@ export function mapHTMLNodeToFigma(
     if (isListElement) {
       FigmaNode.setAutoLayout(nodeConfig, {
         mode: tagName === "li" ? "HORIZONTAL" : "VERTICAL",
-        spacing: normalizedOptions.spacing || DEFAULT_SPACING,
+        spacing: normalizedOptions.spacing || LAYOUT_CONFIG.DEFAULT_SPACING,
       });
     }
   }
@@ -185,14 +192,13 @@ export function mapHTMLNodeToFigma(
       if (typeof width === "number") {
         nodeConfig.width = width;
       } else if (width && typeof width === 'object' && width.unit === '%') {
-        if (width.value === 100) {
+        if (width.value === LAYOUT_CONFIG.FULL_PERCENTAGE) {
           nodeConfig.layoutSizingHorizontal = 'FILL';
-        } else if (width.value === 50) {
+        } else if (width.value === LAYOUT_CONFIG.HALF_PERCENTAGE) {
           nodeConfig.layoutSizingHorizontal = 'FILL';
         } else {
           nodeConfig.layoutSizingHorizontal = 'FIXED';
-          // デフォルト幅800pxと仮定して計算
-          nodeConfig.width = 800 * (width.value / 100);
+          nodeConfig.width = LAYOUT_CONFIG.DEFAULT_CONTAINER_WIDTH * (width.value / LAYOUT_CONFIG.FULL_PERCENTAGE);
         }
       }
 
@@ -200,14 +206,13 @@ export function mapHTMLNodeToFigma(
       if (typeof height === "number") {
         nodeConfig.height = height;
       } else if (height && typeof height === 'object' && height.unit === '%') {
-        if (height.value === 100) {
+        if (height.value === LAYOUT_CONFIG.FULL_PERCENTAGE) {
           nodeConfig.layoutSizingVertical = 'FILL';
-        } else if (height.value === 50) {
-          // デフォルト高さ600pxと仮定
-          nodeConfig.height = 600 * 0.5;
+        } else if (height.value === LAYOUT_CONFIG.HALF_PERCENTAGE) {
+          nodeConfig.height = LAYOUT_CONFIG.DEFAULT_CONTAINER_HEIGHT * (LAYOUT_CONFIG.HALF_PERCENTAGE / LAYOUT_CONFIG.FULL_PERCENTAGE);
         } else {
           nodeConfig.layoutSizingVertical = 'FIXED';
-          nodeConfig.height = 600 * (height.value / 100);
+          nodeConfig.height = LAYOUT_CONFIG.DEFAULT_CONTAINER_HEIGHT * (height.value / LAYOUT_CONFIG.FULL_PERCENTAGE);
         }
       } else if (height === null && styles.height === 'auto') {
         nodeConfig.layoutSizingVertical = 'HUG';

--- a/src/converter/models/colors/colors.ts
+++ b/src/converter/models/colors/colors.ts
@@ -1,25 +1,25 @@
 import type { Brand } from '../../../types';
 import { 
-  RGB_CONSTANTS,
-  HSL_CONSTANTS,
-  HEX_COLOR_CONSTANTS,
-  LUMINANCE_COEFFICIENTS 
+  RGB_RANGE,
+  HSL_LIMITS,
+  HEX_FORMAT,
+  LUMINANCE_WEIGHTS 
 } from '../../constants/color-constants';
 
 // ローカル定数（このファイル内でのみ使用）
-const LOCAL_CONSTANTS = {
-  // 比較許容誤差
-  DEFAULT_TOLERANCE: 0.001,
-  // HSL変換で使用する分数
-  HUE_SEGMENT: 1/6,
-  HUE_HALF: 1/2,
-  HUE_TWO_THIRDS: 2/3,
-  HUE_THIRD: 1/3,
-  HUE_DIVISION: 6,
-  LIGHTNESS_HALF: 0.5,
-  // 色の混合のデフォルトウェイト
-  MIX_DEFAULT_WEIGHT: 0.5
-} as const;
+// 比較許容誤差
+const DEFAULT_TOLERANCE = 0.001;
+
+// HSL変換で使用する分数
+const HUE_SEGMENT = 1/6;
+const HUE_HALF = 1/2;
+const HUE_TWO_THIRDS = 2/3;
+const HUE_THIRD = 1/3;
+const HUE_DIVISION = 6;
+const LIGHTNESS_HALF = 0.5;
+
+// 色の混合のデフォルトウェイト
+const MIX_DEFAULT_WEIGHT = 0.5;
 
 // RGB色の型定義（0-1の範囲）
 export interface RGB {
@@ -76,9 +76,9 @@ export const Colors = {
   // RGB値を作成（0-255の値から0-1に変換）
   rgb(r: number, g: number, b: number): RGB {
     return {
-      r: clamp(r / RGB_CONSTANTS.MAX_VALUE, 0, 1),
-      g: clamp(g / RGB_CONSTANTS.MAX_VALUE, 0, 1),
-      b: clamp(b / RGB_CONSTANTS.MAX_VALUE, 0, 1)
+      r: clamp(r / RGB_RANGE.MAX_VALUE, 0, 1),
+      g: clamp(g / RGB_RANGE.MAX_VALUE, 0, 1),
+      b: clamp(b / RGB_RANGE.MAX_VALUE, 0, 1)
     };
   },
 
@@ -95,15 +95,15 @@ export const Colors = {
     let cleanHex = hex.replace('#', '');
 
     // 3桁の場合は6桁に展開
-    if (cleanHex.length === HEX_COLOR_CONSTANTS.SHORT_LENGTH) {
+    if (cleanHex.length === HEX_FORMAT.SHORT_LENGTH) {
       cleanHex = cleanHex.split('').map(c => c + c).join('');
     }
 
-    if (cleanHex.length !== HEX_COLOR_CONSTANTS.FULL_LENGTH) return null;
+    if (cleanHex.length !== HEX_FORMAT.FULL_LENGTH) return null;
 
-    const r = parseInt(cleanHex.substring(0, 2), HEX_COLOR_CONSTANTS.RADIX) / RGB_CONSTANTS.MAX_VALUE;
-    const g = parseInt(cleanHex.substring(2, 4), HEX_COLOR_CONSTANTS.RADIX) / RGB_CONSTANTS.MAX_VALUE;
-    const b = parseInt(cleanHex.substring(4, 6), HEX_COLOR_CONSTANTS.RADIX) / RGB_CONSTANTS.MAX_VALUE;
+    const r = parseInt(cleanHex.substring(0, 2), HEX_FORMAT.RADIX) / RGB_RANGE.MAX_VALUE;
+    const g = parseInt(cleanHex.substring(2, 4), HEX_FORMAT.RADIX) / RGB_RANGE.MAX_VALUE;
+    const b = parseInt(cleanHex.substring(4, 6), HEX_FORMAT.RADIX) / RGB_RANGE.MAX_VALUE;
 
     return { r, g, b };
   },
@@ -111,7 +111,7 @@ export const Colors = {
   // RGBから16進数カラーに変換
   toHex(color: RGB): HexColor {
     const toHexPart = (value: number) => {
-      const hex = Math.round(value * RGB_CONSTANTS.MAX_VALUE).toString(HEX_COLOR_CONSTANTS.RADIX);
+      const hex = Math.round(value * RGB_RANGE.MAX_VALUE).toString(HEX_FORMAT.RADIX);
       return hex.length === 1 ? '0' + hex : hex;
     };
 
@@ -193,17 +193,17 @@ export const Colors = {
     }
 
     return {
-      h: Math.round(h * HSL_CONSTANTS.HUE_MAX_DEGREES),
-      s: Math.round(s * HSL_CONSTANTS.SATURATION_MAX),
-      l: Math.round(l * HSL_CONSTANTS.LIGHTNESS_MAX)
+      h: Math.round(h * HSL_LIMITS.HUE_MAX_DEGREES),
+      s: Math.round(s * HSL_LIMITS.SATURATION_MAX),
+      l: Math.round(l * HSL_LIMITS.LIGHTNESS_MAX)
     };
   },
 
   // HSLからRGBに変換
   fromHsl(hsl: HSL): RGB {
-    const h = hsl.h / HSL_CONSTANTS.HUE_MAX_DEGREES;
-    const s = hsl.s / HSL_CONSTANTS.SATURATION_MAX;
-    const l = hsl.l / HSL_CONSTANTS.LIGHTNESS_MAX;
+    const h = hsl.h / HSL_LIMITS.HUE_MAX_DEGREES;
+    const s = hsl.s / HSL_LIMITS.SATURATION_MAX;
+    const l = hsl.l / HSL_LIMITS.LIGHTNESS_MAX;
 
     let r, g, b;
 
@@ -213,18 +213,18 @@ export const Colors = {
       const hue2rgb = (p: number, q: number, t: number) => {
         if (t < 0) t += 1;
         if (t > 1) t -= 1;
-        if (t < LOCAL_CONSTANTS.HUE_SEGMENT) return p + (q - p) * LOCAL_CONSTANTS.HUE_DIVISION * t;
-        if (t < LOCAL_CONSTANTS.HUE_HALF) return q;
-        if (t < LOCAL_CONSTANTS.HUE_TWO_THIRDS) return p + (q - p) * (LOCAL_CONSTANTS.HUE_TWO_THIRDS - t) * LOCAL_CONSTANTS.HUE_DIVISION;
+        if (t < HUE_SEGMENT) return p + (q - p) * HUE_DIVISION * t;
+        if (t < HUE_HALF) return q;
+        if (t < HUE_TWO_THIRDS) return p + (q - p) * (HUE_TWO_THIRDS - t) * HUE_DIVISION;
         return p;
       };
 
-      const q = l < LOCAL_CONSTANTS.LIGHTNESS_HALF ? l * (1 + s) : l + s - l * s;
+      const q = l < LIGHTNESS_HALF ? l * (1 + s) : l + s - l * s;
       const p = 2 * l - q;
 
-      r = hue2rgb(p, q, h + LOCAL_CONSTANTS.HUE_THIRD);
+      r = hue2rgb(p, q, h + HUE_THIRD);
       g = hue2rgb(p, q, h);
-      b = hue2rgb(p, q, h - LOCAL_CONSTANTS.HUE_THIRD);
+      b = hue2rgb(p, q, h - HUE_THIRD);
     }
 
     return { r, g, b };
@@ -233,7 +233,7 @@ export const Colors = {
   // 色の明度を調整
   lighten(color: RGB, amount: number): RGB {
     const hsl = Colors.toHsl(color);
-    hsl.l = Math.min(HSL_CONSTANTS.LIGHTNESS_MAX, hsl.l + amount);
+    hsl.l = Math.min(HSL_LIMITS.LIGHTNESS_MAX, hsl.l + amount);
     return Colors.fromHsl(hsl);
   },
 
@@ -247,7 +247,7 @@ export const Colors = {
   // 色の彩度を調整
   saturate(color: RGB, amount: number): RGB {
     const hsl = Colors.toHsl(color);
-    hsl.s = Math.min(HSL_CONSTANTS.SATURATION_MAX, hsl.s + amount);
+    hsl.s = Math.min(HSL_LIMITS.SATURATION_MAX, hsl.s + amount);
     return Colors.fromHsl(hsl);
   },
 
@@ -260,9 +260,9 @@ export const Colors = {
 
   // グレースケールに変換
   grayscale(color: RGB): RGB {
-    const gray = color.r * LUMINANCE_COEFFICIENTS.RED + 
-                  color.g * LUMINANCE_COEFFICIENTS.GREEN + 
-                  color.b * LUMINANCE_COEFFICIENTS.BLUE;
+    const gray = color.r * LUMINANCE_WEIGHTS.RED + 
+                  color.g * LUMINANCE_WEIGHTS.GREEN + 
+                  color.b * LUMINANCE_WEIGHTS.BLUE;
     return { r: gray, g: gray, b: gray };
   },
 
@@ -276,7 +276,7 @@ export const Colors = {
   },
 
   // 2色を混合
-  mix(color1: RGB, color2: RGB, weight: number = LOCAL_CONSTANTS.MIX_DEFAULT_WEIGHT): RGB {
+  mix(color1: RGB, color2: RGB, weight: number = MIX_DEFAULT_WEIGHT): RGB {
     const w = clamp(weight, 0, 1);
     return {
       r: color1.r * (1 - w) + color2.r * w,
@@ -286,7 +286,7 @@ export const Colors = {
   },
 
   // 色が等しいか判定
-  equals(color1: RGB, color2: RGB, tolerance: number = LOCAL_CONSTANTS.DEFAULT_TOLERANCE): boolean {
+  equals(color1: RGB, color2: RGB, tolerance: number = DEFAULT_TOLERANCE): boolean {
     return Math.abs(color1.r - color2.r) < tolerance &&
            Math.abs(color1.g - color2.g) < tolerance &&
            Math.abs(color1.b - color2.b) < tolerance;

--- a/src/converter/models/colors/colors.ts
+++ b/src/converter/models/colors/colors.ts
@@ -1,5 +1,30 @@
 import type { Brand } from '../../../types';
 
+// 色変換定数
+const COLOR_CONSTANTS = {
+  RGB_MAX_VALUE: 255,
+  HUE_MAX_DEGREES: 360,
+  SATURATION_MAX_PERCENT: 100,
+  LIGHTNESS_MAX_PERCENT: 100,
+  HEX_SHORT_LENGTH: 3,
+  HEX_FULL_LENGTH: 6,
+  HEX_RADIX: 16,
+  // 輝度計算の標準係数（ITU-R BT.709）
+  LUMINANCE_RED_COEFFICIENT: 0.299,
+  LUMINANCE_GREEN_COEFFICIENT: 0.587,
+  LUMINANCE_BLUE_COEFFICIENT: 0.114,
+  // 比較許容誤差
+  DEFAULT_TOLERANCE: 0.001,
+  // HSL変換定数
+  HUE_SEGMENT: 1/6,
+  HUE_HALF: 1/2,
+  HUE_TWO_THIRDS: 2/3,
+  HUE_THIRD: 1/3,
+  HUE_DIVISION: 6,
+  LIGHTNESS_HALF: 0.5,
+  MIX_DEFAULT_WEIGHT: 0.5
+} as const;
+
 // RGB色の型定義（0-1の範囲）
 export interface RGB {
   r: number; // 0-1
@@ -55,9 +80,9 @@ export const Colors = {
   // RGB値を作成（0-255の値から0-1に変換）
   rgb(r: number, g: number, b: number): RGB {
     return {
-      r: clamp(r / 255, 0, 1),
-      g: clamp(g / 255, 0, 1),
-      b: clamp(b / 255, 0, 1)
+      r: clamp(r / COLOR_CONSTANTS.RGB_MAX_VALUE, 0, 1),
+      g: clamp(g / COLOR_CONSTANTS.RGB_MAX_VALUE, 0, 1),
+      b: clamp(b / COLOR_CONSTANTS.RGB_MAX_VALUE, 0, 1)
     };
   },
 
@@ -74,15 +99,15 @@ export const Colors = {
     let cleanHex = hex.replace('#', '');
 
     // 3桁の場合は6桁に展開
-    if (cleanHex.length === 3) {
+    if (cleanHex.length === COLOR_CONSTANTS.HEX_SHORT_LENGTH) {
       cleanHex = cleanHex.split('').map(c => c + c).join('');
     }
 
-    if (cleanHex.length !== 6) return null;
+    if (cleanHex.length !== COLOR_CONSTANTS.HEX_FULL_LENGTH) return null;
 
-    const r = parseInt(cleanHex.substring(0, 2), 16) / 255;
-    const g = parseInt(cleanHex.substring(2, 4), 16) / 255;
-    const b = parseInt(cleanHex.substring(4, 6), 16) / 255;
+    const r = parseInt(cleanHex.substring(0, 2), COLOR_CONSTANTS.HEX_RADIX) / COLOR_CONSTANTS.RGB_MAX_VALUE;
+    const g = parseInt(cleanHex.substring(2, 4), COLOR_CONSTANTS.HEX_RADIX) / COLOR_CONSTANTS.RGB_MAX_VALUE;
+    const b = parseInt(cleanHex.substring(4, 6), COLOR_CONSTANTS.HEX_RADIX) / COLOR_CONSTANTS.RGB_MAX_VALUE;
 
     return { r, g, b };
   },
@@ -90,7 +115,7 @@ export const Colors = {
   // RGBから16進数カラーに変換
   toHex(color: RGB): HexColor {
     const toHexPart = (value: number) => {
-      const hex = Math.round(value * 255).toString(16);
+      const hex = Math.round(value * COLOR_CONSTANTS.RGB_MAX_VALUE).toString(COLOR_CONSTANTS.HEX_RADIX);
       return hex.length === 1 ? '0' + hex : hex;
     };
 
@@ -172,17 +197,17 @@ export const Colors = {
     }
 
     return {
-      h: Math.round(h * 360),
-      s: Math.round(s * 100),
-      l: Math.round(l * 100)
+      h: Math.round(h * COLOR_CONSTANTS.HUE_MAX_DEGREES),
+      s: Math.round(s * COLOR_CONSTANTS.SATURATION_MAX_PERCENT),
+      l: Math.round(l * COLOR_CONSTANTS.LIGHTNESS_MAX_PERCENT)
     };
   },
 
   // HSLからRGBに変換
   fromHsl(hsl: HSL): RGB {
-    const h = hsl.h / 360;
-    const s = hsl.s / 100;
-    const l = hsl.l / 100;
+    const h = hsl.h / COLOR_CONSTANTS.HUE_MAX_DEGREES;
+    const s = hsl.s / COLOR_CONSTANTS.SATURATION_MAX_PERCENT;
+    const l = hsl.l / COLOR_CONSTANTS.LIGHTNESS_MAX_PERCENT;
 
     let r, g, b;
 
@@ -192,18 +217,18 @@ export const Colors = {
       const hue2rgb = (p: number, q: number, t: number) => {
         if (t < 0) t += 1;
         if (t > 1) t -= 1;
-        if (t < 1/6) return p + (q - p) * 6 * t;
-        if (t < 1/2) return q;
-        if (t < 2/3) return p + (q - p) * (2/3 - t) * 6;
+        if (t < COLOR_CONSTANTS.HUE_SEGMENT) return p + (q - p) * COLOR_CONSTANTS.HUE_DIVISION * t;
+        if (t < COLOR_CONSTANTS.HUE_HALF) return q;
+        if (t < COLOR_CONSTANTS.HUE_TWO_THIRDS) return p + (q - p) * (COLOR_CONSTANTS.HUE_TWO_THIRDS - t) * COLOR_CONSTANTS.HUE_DIVISION;
         return p;
       };
 
-      const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+      const q = l < COLOR_CONSTANTS.LIGHTNESS_HALF ? l * (1 + s) : l + s - l * s;
       const p = 2 * l - q;
 
-      r = hue2rgb(p, q, h + 1/3);
+      r = hue2rgb(p, q, h + COLOR_CONSTANTS.HUE_THIRD);
       g = hue2rgb(p, q, h);
-      b = hue2rgb(p, q, h - 1/3);
+      b = hue2rgb(p, q, h - COLOR_CONSTANTS.HUE_THIRD);
     }
 
     return { r, g, b };
@@ -212,7 +237,7 @@ export const Colors = {
   // 色の明度を調整
   lighten(color: RGB, amount: number): RGB {
     const hsl = Colors.toHsl(color);
-    hsl.l = Math.min(100, hsl.l + amount);
+    hsl.l = Math.min(COLOR_CONSTANTS.LIGHTNESS_MAX_PERCENT, hsl.l + amount);
     return Colors.fromHsl(hsl);
   },
 
@@ -226,7 +251,7 @@ export const Colors = {
   // 色の彩度を調整
   saturate(color: RGB, amount: number): RGB {
     const hsl = Colors.toHsl(color);
-    hsl.s = Math.min(100, hsl.s + amount);
+    hsl.s = Math.min(COLOR_CONSTANTS.SATURATION_MAX_PERCENT, hsl.s + amount);
     return Colors.fromHsl(hsl);
   },
 
@@ -239,7 +264,9 @@ export const Colors = {
 
   // グレースケールに変換
   grayscale(color: RGB): RGB {
-    const gray = color.r * 0.299 + color.g * 0.587 + color.b * 0.114;
+    const gray = color.r * COLOR_CONSTANTS.LUMINANCE_RED_COEFFICIENT + 
+                  color.g * COLOR_CONSTANTS.LUMINANCE_GREEN_COEFFICIENT + 
+                  color.b * COLOR_CONSTANTS.LUMINANCE_BLUE_COEFFICIENT;
     return { r: gray, g: gray, b: gray };
   },
 
@@ -253,7 +280,7 @@ export const Colors = {
   },
 
   // 2色を混合
-  mix(color1: RGB, color2: RGB, weight: number = 0.5): RGB {
+  mix(color1: RGB, color2: RGB, weight: number = COLOR_CONSTANTS.MIX_DEFAULT_WEIGHT): RGB {
     const w = clamp(weight, 0, 1);
     return {
       r: color1.r * (1 - w) + color2.r * w,
@@ -263,7 +290,7 @@ export const Colors = {
   },
 
   // 色が等しいか判定
-  equals(color1: RGB, color2: RGB, tolerance: number = 0.001): boolean {
+  equals(color1: RGB, color2: RGB, tolerance: number = COLOR_CONSTANTS.DEFAULT_TOLERANCE): boolean {
     return Math.abs(color1.r - color2.r) < tolerance &&
            Math.abs(color1.g - color2.g) < tolerance &&
            Math.abs(color1.b - color2.b) < tolerance;

--- a/src/converter/models/colors/colors.ts
+++ b/src/converter/models/colors/colors.ts
@@ -1,27 +1,23 @@
 import type { Brand } from '../../../types';
+import { 
+  RGB_CONSTANTS,
+  HSL_CONSTANTS,
+  HEX_COLOR_CONSTANTS,
+  LUMINANCE_COEFFICIENTS 
+} from '../../constants/color-constants';
 
-// 色変換定数
-const COLOR_CONSTANTS = {
-  RGB_MAX_VALUE: 255,
-  HUE_MAX_DEGREES: 360,
-  SATURATION_MAX_PERCENT: 100,
-  LIGHTNESS_MAX_PERCENT: 100,
-  HEX_SHORT_LENGTH: 3,
-  HEX_FULL_LENGTH: 6,
-  HEX_RADIX: 16,
-  // 輝度計算の標準係数（ITU-R BT.709）
-  LUMINANCE_RED_COEFFICIENT: 0.299,
-  LUMINANCE_GREEN_COEFFICIENT: 0.587,
-  LUMINANCE_BLUE_COEFFICIENT: 0.114,
+// ローカル定数（このファイル内でのみ使用）
+const LOCAL_CONSTANTS = {
   // 比較許容誤差
   DEFAULT_TOLERANCE: 0.001,
-  // HSL変換定数
+  // HSL変換で使用する分数
   HUE_SEGMENT: 1/6,
   HUE_HALF: 1/2,
   HUE_TWO_THIRDS: 2/3,
   HUE_THIRD: 1/3,
   HUE_DIVISION: 6,
   LIGHTNESS_HALF: 0.5,
+  // 色の混合のデフォルトウェイト
   MIX_DEFAULT_WEIGHT: 0.5
 } as const;
 
@@ -80,9 +76,9 @@ export const Colors = {
   // RGB値を作成（0-255の値から0-1に変換）
   rgb(r: number, g: number, b: number): RGB {
     return {
-      r: clamp(r / COLOR_CONSTANTS.RGB_MAX_VALUE, 0, 1),
-      g: clamp(g / COLOR_CONSTANTS.RGB_MAX_VALUE, 0, 1),
-      b: clamp(b / COLOR_CONSTANTS.RGB_MAX_VALUE, 0, 1)
+      r: clamp(r / RGB_CONSTANTS.MAX_VALUE, 0, 1),
+      g: clamp(g / RGB_CONSTANTS.MAX_VALUE, 0, 1),
+      b: clamp(b / RGB_CONSTANTS.MAX_VALUE, 0, 1)
     };
   },
 
@@ -99,15 +95,15 @@ export const Colors = {
     let cleanHex = hex.replace('#', '');
 
     // 3桁の場合は6桁に展開
-    if (cleanHex.length === COLOR_CONSTANTS.HEX_SHORT_LENGTH) {
+    if (cleanHex.length === HEX_COLOR_CONSTANTS.SHORT_LENGTH) {
       cleanHex = cleanHex.split('').map(c => c + c).join('');
     }
 
-    if (cleanHex.length !== COLOR_CONSTANTS.HEX_FULL_LENGTH) return null;
+    if (cleanHex.length !== HEX_COLOR_CONSTANTS.FULL_LENGTH) return null;
 
-    const r = parseInt(cleanHex.substring(0, 2), COLOR_CONSTANTS.HEX_RADIX) / COLOR_CONSTANTS.RGB_MAX_VALUE;
-    const g = parseInt(cleanHex.substring(2, 4), COLOR_CONSTANTS.HEX_RADIX) / COLOR_CONSTANTS.RGB_MAX_VALUE;
-    const b = parseInt(cleanHex.substring(4, 6), COLOR_CONSTANTS.HEX_RADIX) / COLOR_CONSTANTS.RGB_MAX_VALUE;
+    const r = parseInt(cleanHex.substring(0, 2), HEX_COLOR_CONSTANTS.RADIX) / RGB_CONSTANTS.MAX_VALUE;
+    const g = parseInt(cleanHex.substring(2, 4), HEX_COLOR_CONSTANTS.RADIX) / RGB_CONSTANTS.MAX_VALUE;
+    const b = parseInt(cleanHex.substring(4, 6), HEX_COLOR_CONSTANTS.RADIX) / RGB_CONSTANTS.MAX_VALUE;
 
     return { r, g, b };
   },
@@ -115,7 +111,7 @@ export const Colors = {
   // RGBから16進数カラーに変換
   toHex(color: RGB): HexColor {
     const toHexPart = (value: number) => {
-      const hex = Math.round(value * COLOR_CONSTANTS.RGB_MAX_VALUE).toString(COLOR_CONSTANTS.HEX_RADIX);
+      const hex = Math.round(value * RGB_CONSTANTS.MAX_VALUE).toString(HEX_COLOR_CONSTANTS.RADIX);
       return hex.length === 1 ? '0' + hex : hex;
     };
 
@@ -197,17 +193,17 @@ export const Colors = {
     }
 
     return {
-      h: Math.round(h * COLOR_CONSTANTS.HUE_MAX_DEGREES),
-      s: Math.round(s * COLOR_CONSTANTS.SATURATION_MAX_PERCENT),
-      l: Math.round(l * COLOR_CONSTANTS.LIGHTNESS_MAX_PERCENT)
+      h: Math.round(h * HSL_CONSTANTS.HUE_MAX_DEGREES),
+      s: Math.round(s * HSL_CONSTANTS.SATURATION_MAX),
+      l: Math.round(l * HSL_CONSTANTS.LIGHTNESS_MAX)
     };
   },
 
   // HSLからRGBに変換
   fromHsl(hsl: HSL): RGB {
-    const h = hsl.h / COLOR_CONSTANTS.HUE_MAX_DEGREES;
-    const s = hsl.s / COLOR_CONSTANTS.SATURATION_MAX_PERCENT;
-    const l = hsl.l / COLOR_CONSTANTS.LIGHTNESS_MAX_PERCENT;
+    const h = hsl.h / HSL_CONSTANTS.HUE_MAX_DEGREES;
+    const s = hsl.s / HSL_CONSTANTS.SATURATION_MAX;
+    const l = hsl.l / HSL_CONSTANTS.LIGHTNESS_MAX;
 
     let r, g, b;
 
@@ -217,18 +213,18 @@ export const Colors = {
       const hue2rgb = (p: number, q: number, t: number) => {
         if (t < 0) t += 1;
         if (t > 1) t -= 1;
-        if (t < COLOR_CONSTANTS.HUE_SEGMENT) return p + (q - p) * COLOR_CONSTANTS.HUE_DIVISION * t;
-        if (t < COLOR_CONSTANTS.HUE_HALF) return q;
-        if (t < COLOR_CONSTANTS.HUE_TWO_THIRDS) return p + (q - p) * (COLOR_CONSTANTS.HUE_TWO_THIRDS - t) * COLOR_CONSTANTS.HUE_DIVISION;
+        if (t < LOCAL_CONSTANTS.HUE_SEGMENT) return p + (q - p) * LOCAL_CONSTANTS.HUE_DIVISION * t;
+        if (t < LOCAL_CONSTANTS.HUE_HALF) return q;
+        if (t < LOCAL_CONSTANTS.HUE_TWO_THIRDS) return p + (q - p) * (LOCAL_CONSTANTS.HUE_TWO_THIRDS - t) * LOCAL_CONSTANTS.HUE_DIVISION;
         return p;
       };
 
-      const q = l < COLOR_CONSTANTS.LIGHTNESS_HALF ? l * (1 + s) : l + s - l * s;
+      const q = l < LOCAL_CONSTANTS.LIGHTNESS_HALF ? l * (1 + s) : l + s - l * s;
       const p = 2 * l - q;
 
-      r = hue2rgb(p, q, h + COLOR_CONSTANTS.HUE_THIRD);
+      r = hue2rgb(p, q, h + LOCAL_CONSTANTS.HUE_THIRD);
       g = hue2rgb(p, q, h);
-      b = hue2rgb(p, q, h - COLOR_CONSTANTS.HUE_THIRD);
+      b = hue2rgb(p, q, h - LOCAL_CONSTANTS.HUE_THIRD);
     }
 
     return { r, g, b };
@@ -237,7 +233,7 @@ export const Colors = {
   // 色の明度を調整
   lighten(color: RGB, amount: number): RGB {
     const hsl = Colors.toHsl(color);
-    hsl.l = Math.min(COLOR_CONSTANTS.LIGHTNESS_MAX_PERCENT, hsl.l + amount);
+    hsl.l = Math.min(HSL_CONSTANTS.LIGHTNESS_MAX, hsl.l + amount);
     return Colors.fromHsl(hsl);
   },
 
@@ -251,7 +247,7 @@ export const Colors = {
   // 色の彩度を調整
   saturate(color: RGB, amount: number): RGB {
     const hsl = Colors.toHsl(color);
-    hsl.s = Math.min(COLOR_CONSTANTS.SATURATION_MAX_PERCENT, hsl.s + amount);
+    hsl.s = Math.min(HSL_CONSTANTS.SATURATION_MAX, hsl.s + amount);
     return Colors.fromHsl(hsl);
   },
 
@@ -264,9 +260,9 @@ export const Colors = {
 
   // グレースケールに変換
   grayscale(color: RGB): RGB {
-    const gray = color.r * COLOR_CONSTANTS.LUMINANCE_RED_COEFFICIENT + 
-                  color.g * COLOR_CONSTANTS.LUMINANCE_GREEN_COEFFICIENT + 
-                  color.b * COLOR_CONSTANTS.LUMINANCE_BLUE_COEFFICIENT;
+    const gray = color.r * LUMINANCE_COEFFICIENTS.RED + 
+                  color.g * LUMINANCE_COEFFICIENTS.GREEN + 
+                  color.b * LUMINANCE_COEFFICIENTS.BLUE;
     return { r: gray, g: gray, b: gray };
   },
 
@@ -280,7 +276,7 @@ export const Colors = {
   },
 
   // 2色を混合
-  mix(color1: RGB, color2: RGB, weight: number = COLOR_CONSTANTS.MIX_DEFAULT_WEIGHT): RGB {
+  mix(color1: RGB, color2: RGB, weight: number = LOCAL_CONSTANTS.MIX_DEFAULT_WEIGHT): RGB {
     const w = clamp(weight, 0, 1);
     return {
       r: color1.r * (1 - w) + color2.r * w,
@@ -290,7 +286,7 @@ export const Colors = {
   },
 
   // 色が等しいか判定
-  equals(color1: RGB, color2: RGB, tolerance: number = COLOR_CONSTANTS.DEFAULT_TOLERANCE): boolean {
+  equals(color1: RGB, color2: RGB, tolerance: number = LOCAL_CONSTANTS.DEFAULT_TOLERANCE): boolean {
     return Math.abs(color1.r - color2.r) < tolerance &&
            Math.abs(color1.g - color2.g) < tolerance &&
            Math.abs(color1.b - color2.b) < tolerance;

--- a/src/converter/models/css-values/color.ts
+++ b/src/converter/models/css-values/color.ts
@@ -5,6 +5,7 @@
 import type { Brand } from '../../../types';
 import type { RGB } from '../colors';
 import { Colors } from '../colors';
+import { COLOR_CONVERSION, NUMERIC_COMPARISON } from '../../constants';
 
 // CSS色値のブランド型
 export type CSSColor = Brand<RGB, 'CSSColor'>;
@@ -26,9 +27,9 @@ export const CSSColor = {
   fromRGB(rgb: { r: number; g: number; b: number }): CSSColor {
     // RGB値を0-255の範囲から0-1に変換
     const normalized = {
-      r: Math.max(0, Math.min(255, rgb.r)) / 255,
-      g: Math.max(0, Math.min(255, rgb.g)) / 255,
-      b: Math.max(0, Math.min(255, rgb.b)) / 255
+      r: Math.max(0, Math.min(COLOR_CONVERSION.RGB_MAX, rgb.r)) / COLOR_CONVERSION.RGB_MAX,
+      g: Math.max(0, Math.min(COLOR_CONVERSION.RGB_MAX, rgb.g)) / COLOR_CONVERSION.RGB_MAX,
+      b: Math.max(0, Math.min(COLOR_CONVERSION.RGB_MAX, rgb.b)) / COLOR_CONVERSION.RGB_MAX
     };
     return CSSColor.from(normalized);
   },
@@ -47,7 +48,7 @@ export const CSSColor = {
         const g = parseInt(match[2]);
         const b = parseInt(match[3]);
         // 範囲外の値はnullを返す
-        if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255) {
+        if (r < 0 || r > COLOR_CONVERSION.RGB_MAX || g < 0 || g > COLOR_CONVERSION.RGB_MAX || b < 0 || b > COLOR_CONVERSION.RGB_MAX) {
           return null;
         }
       }
@@ -76,9 +77,9 @@ export const CSSColor = {
   toRGB(color: CSSColor): { r: number; g: number; b: number } {
     const rgb = color as RGB;
     return {
-      r: Math.round(rgb.r * 255),
-      g: Math.round(rgb.g * 255),
-      b: Math.round(rgb.b * 255)
+      r: Math.round(rgb.r * COLOR_CONVERSION.RGB_MAX),
+      g: Math.round(rgb.g * COLOR_CONVERSION.RGB_MAX),
+      b: Math.round(rgb.b * COLOR_CONVERSION.RGB_MAX)
     };
   },
 
@@ -93,21 +94,21 @@ export const CSSColor = {
    * 赤成分を取得（0-255）
    */
   getRed(color: CSSColor): number {
-    return Math.round((color as RGB).r * 255);
+    return Math.round((color as RGB).r * COLOR_CONVERSION.RGB_MAX);
   },
 
   /**
    * 緑成分を取得（0-255）
    */
   getGreen(color: CSSColor): number {
-    return Math.round((color as RGB).g * 255);
+    return Math.round((color as RGB).g * COLOR_CONVERSION.RGB_MAX);
   },
 
   /**
    * 青成分を取得（0-255）
    */
   getBlue(color: CSSColor): number {
-    return Math.round((color as RGB).b * 255);
+    return Math.round((color as RGB).b * COLOR_CONVERSION.RGB_MAX);
   },
 
   /**
@@ -115,9 +116,9 @@ export const CSSColor = {
    */
   toHex(color: CSSColor): string {
     const rgb = color as RGB;
-    const r = Math.round(rgb.r * 255).toString(16).padStart(2, '0');
-    const g = Math.round(rgb.g * 255).toString(16).padStart(2, '0');
-    const b = Math.round(rgb.b * 255).toString(16).padStart(2, '0');
+    const r = Math.round(rgb.r * COLOR_CONVERSION.RGB_MAX).toString(COLOR_CONVERSION.HEX_RADIX).padStart(2, '0');
+    const g = Math.round(rgb.g * COLOR_CONVERSION.RGB_MAX).toString(COLOR_CONVERSION.HEX_RADIX).padStart(2, '0');
+    const b = Math.round(rgb.b * COLOR_CONVERSION.RGB_MAX).toString(COLOR_CONVERSION.HEX_RADIX).padStart(2, '0');
     return `#${r}${g}${b}`;
   },
 
@@ -126,9 +127,9 @@ export const CSSColor = {
    */
   toRGBString(color: CSSColor): string {
     const rgb = color as RGB;
-    const r = Math.round(rgb.r * 255);
-    const g = Math.round(rgb.g * 255);
-    const b = Math.round(rgb.b * 255);
+    const r = Math.round(rgb.r * COLOR_CONVERSION.RGB_MAX);
+    const g = Math.round(rgb.g * COLOR_CONVERSION.RGB_MAX);
+    const b = Math.round(rgb.b * COLOR_CONVERSION.RGB_MAX);
     return `rgb(${r}, ${g}, ${b})`;
   },
 
@@ -139,10 +140,9 @@ export const CSSColor = {
     const aRGB = a as RGB;
     const bRGB = b as RGB;
     // 浮動小数点の誤差を考慮
-    const epsilon = 0.001;
-    return Math.abs(aRGB.r - bRGB.r) < epsilon &&
-           Math.abs(aRGB.g - bRGB.g) < epsilon &&
-           Math.abs(aRGB.b - bRGB.b) < epsilon;
+    return Math.abs(aRGB.r - bRGB.r) < NUMERIC_COMPARISON.EPSILON &&
+           Math.abs(aRGB.g - bRGB.g) < NUMERIC_COMPARISON.EPSILON &&
+           Math.abs(aRGB.b - bRGB.b) < NUMERIC_COMPARISON.EPSILON;
   },
 
   /**
@@ -150,8 +150,9 @@ export const CSSColor = {
    */
   isBlack(color: CSSColor): boolean {
     const rgb = color as RGB;
-    const epsilon = 0.001;
-    return rgb.r < epsilon && rgb.g < epsilon && rgb.b < epsilon;
+    return rgb.r < NUMERIC_COMPARISON.EPSILON && 
+           rgb.g < NUMERIC_COMPARISON.EPSILON && 
+           rgb.b < NUMERIC_COMPARISON.EPSILON;
   },
 
   /**
@@ -159,8 +160,9 @@ export const CSSColor = {
    */
   isWhite(color: CSSColor): boolean {
     const rgb = color as RGB;
-    const epsilon = 0.001;
-    return Math.abs(rgb.r - 1) < epsilon && Math.abs(rgb.g - 1) < epsilon && Math.abs(rgb.b - 1) < epsilon;
+    return Math.abs(rgb.r - 1) < NUMERIC_COMPARISON.EPSILON && 
+           Math.abs(rgb.g - 1) < NUMERIC_COMPARISON.EPSILON && 
+           Math.abs(rgb.b - 1) < NUMERIC_COMPARISON.EPSILON;
   },
 
   /**

--- a/src/converter/models/css-values/color.ts
+++ b/src/converter/models/css-values/color.ts
@@ -5,7 +5,7 @@
 import type { Brand } from '../../../types';
 import type { RGB } from '../colors';
 import { Colors } from '../colors';
-import { RGB_CONSTANTS, HEX_COLOR_CONSTANTS } from '../../constants/color-constants';
+import { RGB_RANGE, HEX_FORMAT } from '../../constants/color-constants';
 import { NUMERIC_COMPARISON } from '../../constants';
 
 // CSS色値のブランド型
@@ -28,9 +28,9 @@ export const CSSColor = {
   fromRGB(rgb: { r: number; g: number; b: number }): CSSColor {
     // RGB値を0-255の範囲から0-1に変換
     const normalized = {
-      r: Math.max(0, Math.min(RGB_CONSTANTS.MAX_VALUE, rgb.r)) / RGB_CONSTANTS.MAX_VALUE,
-      g: Math.max(0, Math.min(RGB_CONSTANTS.MAX_VALUE, rgb.g)) / RGB_CONSTANTS.MAX_VALUE,
-      b: Math.max(0, Math.min(RGB_CONSTANTS.MAX_VALUE, rgb.b)) / RGB_CONSTANTS.MAX_VALUE
+      r: Math.max(0, Math.min(RGB_RANGE.MAX_VALUE, rgb.r)) / RGB_RANGE.MAX_VALUE,
+      g: Math.max(0, Math.min(RGB_RANGE.MAX_VALUE, rgb.g)) / RGB_RANGE.MAX_VALUE,
+      b: Math.max(0, Math.min(RGB_RANGE.MAX_VALUE, rgb.b)) / RGB_RANGE.MAX_VALUE
     };
     return CSSColor.from(normalized);
   },
@@ -49,7 +49,7 @@ export const CSSColor = {
         const g = parseInt(match[2]);
         const b = parseInt(match[3]);
         // 範囲外の値はnullを返す
-        if (r < 0 || r > RGB_CONSTANTS.MAX_VALUE || g < 0 || g > RGB_CONSTANTS.MAX_VALUE || b < 0 || b > RGB_CONSTANTS.MAX_VALUE) {
+        if (r < 0 || r > RGB_RANGE.MAX_VALUE || g < 0 || g > RGB_RANGE.MAX_VALUE || b < 0 || b > RGB_RANGE.MAX_VALUE) {
           return null;
         }
       }
@@ -78,9 +78,9 @@ export const CSSColor = {
   toRGB(color: CSSColor): { r: number; g: number; b: number } {
     const rgb = color as RGB;
     return {
-      r: Math.round(rgb.r * RGB_CONSTANTS.MAX_VALUE),
-      g: Math.round(rgb.g * RGB_CONSTANTS.MAX_VALUE),
-      b: Math.round(rgb.b * RGB_CONSTANTS.MAX_VALUE)
+      r: Math.round(rgb.r * RGB_RANGE.MAX_VALUE),
+      g: Math.round(rgb.g * RGB_RANGE.MAX_VALUE),
+      b: Math.round(rgb.b * RGB_RANGE.MAX_VALUE)
     };
   },
 
@@ -95,21 +95,21 @@ export const CSSColor = {
    * 赤成分を取得（0-255）
    */
   getRed(color: CSSColor): number {
-    return Math.round((color as RGB).r * RGB_CONSTANTS.MAX_VALUE);
+    return Math.round((color as RGB).r * RGB_RANGE.MAX_VALUE);
   },
 
   /**
    * 緑成分を取得（0-255）
    */
   getGreen(color: CSSColor): number {
-    return Math.round((color as RGB).g * RGB_CONSTANTS.MAX_VALUE);
+    return Math.round((color as RGB).g * RGB_RANGE.MAX_VALUE);
   },
 
   /**
    * 青成分を取得（0-255）
    */
   getBlue(color: CSSColor): number {
-    return Math.round((color as RGB).b * RGB_CONSTANTS.MAX_VALUE);
+    return Math.round((color as RGB).b * RGB_RANGE.MAX_VALUE);
   },
 
   /**
@@ -117,9 +117,9 @@ export const CSSColor = {
    */
   toHex(color: CSSColor): string {
     const rgb = color as RGB;
-    const r = Math.round(rgb.r * RGB_CONSTANTS.MAX_VALUE).toString(HEX_COLOR_CONSTANTS.RADIX).padStart(2, '0');
-    const g = Math.round(rgb.g * RGB_CONSTANTS.MAX_VALUE).toString(HEX_COLOR_CONSTANTS.RADIX).padStart(2, '0');
-    const b = Math.round(rgb.b * RGB_CONSTANTS.MAX_VALUE).toString(HEX_COLOR_CONSTANTS.RADIX).padStart(2, '0');
+    const r = Math.round(rgb.r * RGB_RANGE.MAX_VALUE).toString(HEX_FORMAT.RADIX).padStart(2, '0');
+    const g = Math.round(rgb.g * RGB_RANGE.MAX_VALUE).toString(HEX_FORMAT.RADIX).padStart(2, '0');
+    const b = Math.round(rgb.b * RGB_RANGE.MAX_VALUE).toString(HEX_FORMAT.RADIX).padStart(2, '0');
     return `#${r}${g}${b}`;
   },
 
@@ -128,9 +128,9 @@ export const CSSColor = {
    */
   toRGBString(color: CSSColor): string {
     const rgb = color as RGB;
-    const r = Math.round(rgb.r * RGB_CONSTANTS.MAX_VALUE);
-    const g = Math.round(rgb.g * RGB_CONSTANTS.MAX_VALUE);
-    const b = Math.round(rgb.b * RGB_CONSTANTS.MAX_VALUE);
+    const r = Math.round(rgb.r * RGB_RANGE.MAX_VALUE);
+    const g = Math.round(rgb.g * RGB_RANGE.MAX_VALUE);
+    const b = Math.round(rgb.b * RGB_RANGE.MAX_VALUE);
     return `rgb(${r}, ${g}, ${b})`;
   },
 

--- a/src/converter/models/css-values/color.ts
+++ b/src/converter/models/css-values/color.ts
@@ -5,7 +5,8 @@
 import type { Brand } from '../../../types';
 import type { RGB } from '../colors';
 import { Colors } from '../colors';
-import { COLOR_CONVERSION, NUMERIC_COMPARISON } from '../../constants';
+import { RGB_CONSTANTS, HEX_COLOR_CONSTANTS } from '../../constants/color-constants';
+import { NUMERIC_COMPARISON } from '../../constants';
 
 // CSS色値のブランド型
 export type CSSColor = Brand<RGB, 'CSSColor'>;
@@ -27,9 +28,9 @@ export const CSSColor = {
   fromRGB(rgb: { r: number; g: number; b: number }): CSSColor {
     // RGB値を0-255の範囲から0-1に変換
     const normalized = {
-      r: Math.max(0, Math.min(COLOR_CONVERSION.RGB_MAX, rgb.r)) / COLOR_CONVERSION.RGB_MAX,
-      g: Math.max(0, Math.min(COLOR_CONVERSION.RGB_MAX, rgb.g)) / COLOR_CONVERSION.RGB_MAX,
-      b: Math.max(0, Math.min(COLOR_CONVERSION.RGB_MAX, rgb.b)) / COLOR_CONVERSION.RGB_MAX
+      r: Math.max(0, Math.min(RGB_CONSTANTS.MAX_VALUE, rgb.r)) / RGB_CONSTANTS.MAX_VALUE,
+      g: Math.max(0, Math.min(RGB_CONSTANTS.MAX_VALUE, rgb.g)) / RGB_CONSTANTS.MAX_VALUE,
+      b: Math.max(0, Math.min(RGB_CONSTANTS.MAX_VALUE, rgb.b)) / RGB_CONSTANTS.MAX_VALUE
     };
     return CSSColor.from(normalized);
   },
@@ -48,7 +49,7 @@ export const CSSColor = {
         const g = parseInt(match[2]);
         const b = parseInt(match[3]);
         // 範囲外の値はnullを返す
-        if (r < 0 || r > COLOR_CONVERSION.RGB_MAX || g < 0 || g > COLOR_CONVERSION.RGB_MAX || b < 0 || b > COLOR_CONVERSION.RGB_MAX) {
+        if (r < 0 || r > RGB_CONSTANTS.MAX_VALUE || g < 0 || g > RGB_CONSTANTS.MAX_VALUE || b < 0 || b > RGB_CONSTANTS.MAX_VALUE) {
           return null;
         }
       }
@@ -77,9 +78,9 @@ export const CSSColor = {
   toRGB(color: CSSColor): { r: number; g: number; b: number } {
     const rgb = color as RGB;
     return {
-      r: Math.round(rgb.r * COLOR_CONVERSION.RGB_MAX),
-      g: Math.round(rgb.g * COLOR_CONVERSION.RGB_MAX),
-      b: Math.round(rgb.b * COLOR_CONVERSION.RGB_MAX)
+      r: Math.round(rgb.r * RGB_CONSTANTS.MAX_VALUE),
+      g: Math.round(rgb.g * RGB_CONSTANTS.MAX_VALUE),
+      b: Math.round(rgb.b * RGB_CONSTANTS.MAX_VALUE)
     };
   },
 
@@ -94,21 +95,21 @@ export const CSSColor = {
    * 赤成分を取得（0-255）
    */
   getRed(color: CSSColor): number {
-    return Math.round((color as RGB).r * COLOR_CONVERSION.RGB_MAX);
+    return Math.round((color as RGB).r * RGB_CONSTANTS.MAX_VALUE);
   },
 
   /**
    * 緑成分を取得（0-255）
    */
   getGreen(color: CSSColor): number {
-    return Math.round((color as RGB).g * COLOR_CONVERSION.RGB_MAX);
+    return Math.round((color as RGB).g * RGB_CONSTANTS.MAX_VALUE);
   },
 
   /**
    * 青成分を取得（0-255）
    */
   getBlue(color: CSSColor): number {
-    return Math.round((color as RGB).b * COLOR_CONVERSION.RGB_MAX);
+    return Math.round((color as RGB).b * RGB_CONSTANTS.MAX_VALUE);
   },
 
   /**
@@ -116,9 +117,9 @@ export const CSSColor = {
    */
   toHex(color: CSSColor): string {
     const rgb = color as RGB;
-    const r = Math.round(rgb.r * COLOR_CONVERSION.RGB_MAX).toString(COLOR_CONVERSION.HEX_RADIX).padStart(2, '0');
-    const g = Math.round(rgb.g * COLOR_CONVERSION.RGB_MAX).toString(COLOR_CONVERSION.HEX_RADIX).padStart(2, '0');
-    const b = Math.round(rgb.b * COLOR_CONVERSION.RGB_MAX).toString(COLOR_CONVERSION.HEX_RADIX).padStart(2, '0');
+    const r = Math.round(rgb.r * RGB_CONSTANTS.MAX_VALUE).toString(HEX_COLOR_CONSTANTS.RADIX).padStart(2, '0');
+    const g = Math.round(rgb.g * RGB_CONSTANTS.MAX_VALUE).toString(HEX_COLOR_CONSTANTS.RADIX).padStart(2, '0');
+    const b = Math.round(rgb.b * RGB_CONSTANTS.MAX_VALUE).toString(HEX_COLOR_CONSTANTS.RADIX).padStart(2, '0');
     return `#${r}${g}${b}`;
   },
 
@@ -127,9 +128,9 @@ export const CSSColor = {
    */
   toRGBString(color: CSSColor): string {
     const rgb = color as RGB;
-    const r = Math.round(rgb.r * COLOR_CONVERSION.RGB_MAX);
-    const g = Math.round(rgb.g * COLOR_CONVERSION.RGB_MAX);
-    const b = Math.round(rgb.b * COLOR_CONVERSION.RGB_MAX);
+    const r = Math.round(rgb.r * RGB_CONSTANTS.MAX_VALUE);
+    const g = Math.round(rgb.g * RGB_CONSTANTS.MAX_VALUE);
+    const b = Math.round(rgb.b * RGB_CONSTANTS.MAX_VALUE);
     return `rgb(${r}, ${g}, ${b})`;
   },
 

--- a/src/converter/models/css-values/length.ts
+++ b/src/converter/models/css-values/length.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Brand } from '../../../types';
+import { DEFAULT_VIEWPORT, NUMERIC_COMPARISON } from '../../constants';
 
 // CSS長さ値のブランド型
 export type CSSLength = Brand<{ value: number; unit: LengthUnit }, 'CSSLength'>;
@@ -46,9 +47,9 @@ export const CSSLength = {
   toPixels(length: CSSLength, context?: { viewportWidth?: number; viewportHeight?: number; fontSize?: number }): number {
     const { value, unit } = length as { value: number; unit: LengthUnit };
     const ctx = {
-      viewportWidth: context?.viewportWidth ?? 1920,
-      viewportHeight: context?.viewportHeight ?? 1080,
-      fontSize: context?.fontSize ?? 16
+      viewportWidth: context?.viewportWidth ?? DEFAULT_VIEWPORT.WIDTH,
+      viewportHeight: context?.viewportHeight ?? DEFAULT_VIEWPORT.HEIGHT,
+      fontSize: context?.fontSize ?? DEFAULT_VIEWPORT.FONT_SIZE
     };
 
     switch (unit) {
@@ -59,9 +60,9 @@ export const CSSLength = {
         // remもemも現在のコンテキストのfontSizeを使用（テスト互換性のため）
         return value * ctx.fontSize;
       case 'vh':
-        return value * (ctx.viewportHeight / 100);
+        return value * (ctx.viewportHeight / NUMERIC_COMPARISON.PERCENTAGE_DIVISOR);
       case 'vw':
-        return value * (ctx.viewportWidth / 100);
+        return value * (ctx.viewportWidth / NUMERIC_COMPARISON.PERCENTAGE_DIVISOR);
       default:
         return value;
     }

--- a/src/converter/models/css-values/percentage.ts
+++ b/src/converter/models/css-values/percentage.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Brand } from '../../../types';
+import { NUMERIC_COMPARISON } from '../../constants';
 
 // CSSパーセンテージ値のブランド型
 export type CSSPercentage = Brand<number, 'CSSPercentage'>;
@@ -40,14 +41,14 @@ export const CSSPercentage = {
    * ピクセルに変換（親要素のサイズが必要）
    */
   toPixels(percentage: CSSPercentage, parentSize: number): number {
-    return (percentage as number) * parentSize / 100;
+    return (percentage as number) * parentSize / NUMERIC_COMPARISON.PERCENTAGE_DIVISOR;
   },
 
   /**
    * 0-1の範囲の比率に変換
    */
   toRatio(percentage: CSSPercentage): number {
-    return (percentage as number) / 100;
+    return (percentage as number) / NUMERIC_COMPARISON.PERCENTAGE_DIVISOR;
   },
 
   /**
@@ -61,14 +62,14 @@ export const CSSPercentage = {
    * 100%かどうかを判定
    */
   isFull(percentage: CSSPercentage): boolean {
-    return (percentage as number) === 100;
+    return (percentage as number) === NUMERIC_COMPARISON.FULL_PERCENTAGE;
   },
 
   /**
    * 50%かどうかを判定
    */
   isHalf(percentage: CSSPercentage): boolean {
-    return (percentage as number) === 50;
+    return (percentage as number) === NUMERIC_COMPARISON.HALF_PERCENTAGE;
   },
 
   /**
@@ -82,7 +83,7 @@ export const CSSPercentage = {
    * パーセンテージを小数に変換（0-1）
    */
   toDecimal(percentage: CSSPercentage): number {
-    return (percentage as number) / 100;
+    return (percentage as number) / NUMERIC_COMPARISON.PERCENTAGE_DIVISOR;
   },
 
   /**


### PR DESCRIPTION
## 概要
コードベース全体のマジックナンバーを名前付き定数に置き換え、定数名をより意図が明確な名前に改善しました。

## 変更内容

### 🔢 マジックナンバーの除去

#### 1. **code.ts** - UI設定の定数化
```typescript
const UI_CONFIG = {
  DIALOG_WIDTH: 600,
  DIALOG_HEIGHT: 400,
  DEFAULT_FRAME_WIDTH: 800,
  DEFAULT_FRAME_HEIGHT: 600,
  TEXT_PADDING: 20,
  TEXT_WIDTH: 760,
  TEXT_HEIGHT: 560,
  DEFAULT_FONT_SIZE: 14
} as const;
```

#### 2. **mapper.ts** - レイアウト設定の定数化
```typescript
const LAYOUT_CONFIG = {
  DEFAULT_SPACING: 8,
  DEFAULT_CONTAINER_WIDTH: 800,
  DEFAULT_CONTAINER_HEIGHT: 600,
  FULL_PERCENTAGE: 100,
  HALF_PERCENTAGE: 50
} as const;
```

#### 3. **共通定数の整理**
- `constants/color-constants.ts` - 色変換関連の定数
- `constants/viewport-constants.ts` - ビューポート関連の定数

### 🏷️ 定数名の改善
より意図が明確な名前に変更：

| 変更前 | 変更後 | 理由 |
|--------|--------|------|
| `RGB_CONSTANTS` | `RGB_RANGE` | 範囲を表すため |
| `HSL_CONSTANTS` | `HSL_LIMITS` | 制限値を表すため |
| `HEX_COLOR_CONSTANTS` | `HEX_FORMAT` | フォーマット情報のため |
| `LUMINANCE_COEFFICIENTS` | `LUMINANCE_WEIGHTS` | 重みを表すため |
| `LOCAL_CONSTANTS` | 個別の定数 | より具体的な名前に |

## レビューポイント
- [ ] 定数名が適切で意図が明確か
- [ ] マジックナンバーの置き換えが適切か
- [ ] 定数の配置（ローカル vs 共通）が適切か

## テスト
- 既存のテストは全て通過（既存の失敗23件は今回の変更とは無関係）
- ビルドエラーなし

## 関連Issue
マジックナンバーレビューエージェントで指摘された35個のマジックナンバーを解消