### PR TITLE
🚨 [Tests]: figma-nodeのテストファイルを__tests__フォルダに移動

### DIFF
--- a/src/converter/models/figma-node/__tests__/figma-node-factory-methods.test.ts
+++ b/src/converter/models/figma-node/__tests__/figma-node-factory-methods.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest';
-import { FigmaNode } from './figma-node';
+import { FigmaNode } from '../figma-node';
 
 test('createFrame でFrameノードを作成できる', () => {
   const node = FigmaNode.createFrame('MyFrame', {

--- a/src/converter/models/figma-node/__tests__/figma-node-style-helpers.test.ts
+++ b/src/converter/models/figma-node/__tests__/figma-node-style-helpers.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest';
-import { FigmaNode } from './figma-node';
+import { FigmaNode } from '../figma-node';
 
 test('setSize でサイズを設定できる', () => {
   const node = FigmaNode.createFrame('Frame');

--- a/src/converter/models/figma-node/__tests__/figma-node-type-guards.test.ts
+++ b/src/converter/models/figma-node/__tests__/figma-node-type-guards.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest';
-import { FigmaNode } from './figma-node';
+import { FigmaNode } from '../figma-node';
 
 test('isFrame がFrameノードを正しく判定する', () => {
   const frame = FigmaNode.createFrame('Container');


### PR DESCRIPTION
## 概要
`src/converter/models/figma-node/`フォルダ内のテストファイルを、他のモジュールと同じ構造にするため`__tests__`フォルダに移動しました。

## 変更内容
- ✅ `figma-node-factory-methods.test.ts` を `__tests__/` フォルダに移動
- ✅ `figma-node-style-helpers.test.ts` を `__tests__/` フォルダに移動  
- ✅ `figma-node-type-guards.test.ts` を `__tests__/` フォルダに移動

## 影響範囲
- テストファイルの場所のみ変更（ファイル内容の変更なし）
- テストの実行には影響なし

## テスト
- [ ] すべてのテストが正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)