### PR TITLE
♻️ [Refactoring]: BaseElement実装とdiv要素のリファクタリング

### DIFF
--- a/src/converter/elements/base/global-attributes/global-attributes.ts
+++ b/src/converter/elements/base/global-attributes/global-attributes.ts
@@ -1,12 +1,12 @@
 /**
- * HTML要素の共通属性（グローバル属性）
- * 全てのHTML要素で使用可能な属性
- * @see https://developer.mozilla.org/ja/docs/Web/HTML/Global_attributes
+ * 基本的なグローバル属性の型定義
+ * 明示的に定義された属性のみを含む
  */
-export interface GlobalAttributes {
+export interface GlobalAttributesBase {
   // 基本属性
   id?: string;
   className?: string;
+  class?: string;  // classNameの代替
   style?: string;
   title?: string;
   
@@ -27,12 +27,6 @@ export interface GlobalAttributes {
   hidden?: boolean | '';
   draggable?: boolean | 'true' | 'false' | 'auto';
   
-  // データ属性（data-*）
-  [key: `data-${string}`]: string | undefined;
-  
-  // ARIA属性（aria-*）
-  [key: `aria-${string}`]: string | undefined;
-  
   // イベントハンドラ（on*）
   onclick?: string;
   onmouseover?: string;
@@ -49,7 +43,37 @@ export interface GlobalAttributes {
   onsubmit?: string;
   onload?: string;
   onerror?: string;
-  
-  // その他の属性も許可（any型で全ての値を受け入れる）
-  [key: string]: any;
 }
+
+/**
+ * データ属性の型定義
+ */
+export interface DataAttributes {
+  [key: `data-${string}`]: string | undefined;
+}
+
+/**
+ * ARIA属性の型定義
+ */
+export interface AriaAttributes {
+  [key: `aria-${string}`]: string | undefined;
+}
+
+/**
+ * カスタム属性の型定義
+ * 標準外の属性を許可するための型
+ */
+export interface CustomAttributes {
+  [key: string]: string | number | boolean | undefined | null;
+}
+
+/**
+ * HTML要素の共通属性（グローバル属性）
+ * 全てのHTML要素で使用可能な属性
+ * @see https://developer.mozilla.org/ja/docs/Web/HTML/Global_attributes
+ */
+export type GlobalAttributes = 
+  & GlobalAttributesBase
+  & DataAttributes
+  & AriaAttributes
+  & CustomAttributes;

--- a/src/converter/elements/container/div/div-attributes/div-attributes.ts
+++ b/src/converter/elements/container/div/div-attributes/div-attributes.ts
@@ -1,22 +1,10 @@
+import type { GlobalAttributes } from "../../../base/global-attributes";
+
 /**
  * div要素の属性定義
  * HTML Living Standard準拠
+ *
+ * div要素は固有の属性を持たず、グローバル属性のみを受け入れる
+ * 将来的な拡張性と型の明確性のため、型エイリアスとして定義
  */
-export interface DivAttributes {
-  // グローバル属性
-  id?: string;
-  class?: string;
-  style?: string;
-  title?: string;
-  lang?: string;
-  dir?: 'ltr' | 'rtl' | 'auto';
-  hidden?: boolean;
-  tabindex?: string;
-  
-  // データ属性
-  [key: `data-${string}`]: string | undefined;
-  
-  // ARIAアクセシビリティ属性
-  role?: string;
-  [key: `aria-${string}`]: string | undefined;
-}
+export type DivAttributes = GlobalAttributes;

--- a/src/converter/elements/container/div/div-element/div-element.ts
+++ b/src/converter/elements/container/div/div-element/div-element.ts
@@ -3,14 +3,13 @@ import { FigmaNode } from '../../../../models/figma-node';
 import { Styles } from '../../../../models/styles';
 import { Paint } from '../../../../models/paint';
 import type { DivAttributes } from '../div-attributes';
+import type { BaseElement } from '../../../base/base-element';
 
 /**
  * div要素の型定義
- * HTMLNodeから独立した専用の型
+ * BaseElementを拡張した専用の型
  */
-export interface DivElement {
-  type: 'element';
-  tagName: 'div';
+export interface DivElement extends BaseElement<'div'> {
   attributes: DivAttributes;
   children: DivElement[] | [];
 }


### PR DESCRIPTION
## 📋 概要

HTML要素の型定義を改善するため、BaseElementインターフェースを実装し、div要素をリファクタリングしました。

## 🎯 変更内容

### BaseElementインターフェースの実装
- ✅ 全HTML要素の基底となる`BaseElement<T>`インターフェースを定義
- ✅ `GlobalAttributes`インターフェースを実装（グローバル属性の管理）
- ✅ 型ユーティリティを追加（IsEmptyObject、OptionalKeysなど）

### GlobalAttributes型定義の改善
- ✅ `any`型を排除し、型安全性を向上
- ✅ 4つのインターフェースに分割：
  - `GlobalAttributesBase`: 基本的なグローバル属性
  - `DataAttributes`: data-*属性
  - `AriaAttributes`: aria-*属性
  - `CustomAttributes`: カスタム属性
- ✅ ESLintのno-explicit-anyルールに準拠

### div要素のリファクタリング
- ✅ `DivElement`を`BaseElement<'div'>`を継承する形に変更
- ✅ `DivAttributes`を`GlobalAttributes`の型エイリアスとして定義
- ✅ 既存のテストが全て通過することを確認

## ✅ テスト

- [x] 型チェック（`npm run type-check`）: エラーなし
- [x] Lint（`npm run lint`）: エラーなし
- [x] ユニットテスト: 全テストが通過
  - BaseElementのテスト
  - GlobalAttributesのテスト
  - 型ユーティリティのテスト
  - div要素のテスト

## 📝 今後の計画

plan.mdに記載の通り、今後は他のHTML要素も同様の構造にリファクタリングしていく予定です。

## 🔗 関連

- [html-elements-refactoring/plan.md](docs/html-elements-refactoring/plan.md)

🤖 Generated with [Claude Code](https://claude.ai/code)