### PR TITLE
✨ [New Feature]: HTML5のmain要素をFigmaフレームノードに変換する機能を実装

### DIFF
--- a/src/converter/elements/container/index.ts
+++ b/src/converter/elements/container/index.ts
@@ -1,3 +1,4 @@
 export * from "./div";
 export * from "./section";
 export * from "./article";
+export * from "./main";

--- a/src/converter/elements/container/main/index.ts
+++ b/src/converter/elements/container/main/index.ts
@@ -1,0 +1,2 @@
+export { MainElement } from "./main-element";
+export type { MainAttributes } from "./main-attributes";

--- a/src/converter/elements/container/main/main-attributes/__tests__/main-attributes.test.ts
+++ b/src/converter/elements/container/main/main-attributes/__tests__/main-attributes.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import type { MainAttributes } from "../main-attributes";
+import type { GlobalAttributes } from "../../../../base/global-attributes";
+
+describe("MainAttributes", () => {
+  it("GlobalAttributesを継承していること", () => {
+    const attributes: MainAttributes = {
+      id: "main-content",
+      className: "main-container",
+      style: "display: flex;",
+    };
+
+    const globalAttributes: GlobalAttributes = attributes;
+    expect(globalAttributes).toBe(attributes);
+  });
+
+  it("main要素固有の属性がないこと", () => {
+    const attributes: MainAttributes = {};
+    expect(Object.keys(attributes)).toHaveLength(0);
+  });
+
+  it("グローバル属性を設定できること", () => {
+    const attributes: MainAttributes = {
+      id: "main",
+      className: "content",
+      style: "padding: 20px;",
+      title: "メインコンテンツ",
+      lang: "ja",
+      dir: "ltr",
+      hidden: false,
+      tabindex: 0,
+      accesskey: "m",
+      contenteditable: "false",
+      spellcheck: false,
+      draggable: false,
+      translate: "yes",
+    };
+
+    expect(attributes.id).toBe("main");
+    expect(attributes.className).toBe("content");
+    expect(attributes.style).toBe("padding: 20px;");
+    expect(attributes.title).toBe("メインコンテンツ");
+    expect(attributes.lang).toBe("ja");
+    expect(attributes.dir).toBe("ltr");
+    expect(attributes.hidden).toBe(false);
+    expect(attributes.tabindex).toBe(0);
+    expect(attributes.accesskey).toBe("m");
+    expect(attributes.contenteditable).toBe("false");
+    expect(attributes.spellcheck).toBe(false);
+    expect(attributes.draggable).toBe(false);
+    expect(attributes.translate).toBe("yes");
+  });
+
+  it("data-*属性を設定できること", () => {
+    const attributes: MainAttributes = {
+      "data-page": "home",
+      "data-section": "main",
+    };
+
+    expect(attributes["data-page"]).toBe("home");
+    expect(attributes["data-section"]).toBe("main");
+  });
+
+  it("aria-*属性を設定できること", () => {
+    const attributes: MainAttributes = {
+      "aria-label": "メインコンテンツエリア",
+      "aria-hidden": "false",
+      "aria-live": "polite",
+    };
+
+    expect(attributes["aria-label"]).toBe("メインコンテンツエリア");
+    expect(attributes["aria-hidden"]).toBe("false");
+    expect(attributes["aria-live"]).toBe("polite");
+  });
+});

--- a/src/converter/elements/container/main/main-attributes/index.ts
+++ b/src/converter/elements/container/main/main-attributes/index.ts
@@ -1,0 +1,1 @@
+export type { MainAttributes } from "./main-attributes";

--- a/src/converter/elements/container/main/main-attributes/main-attributes.ts
+++ b/src/converter/elements/container/main/main-attributes/main-attributes.ts
@@ -1,0 +1,7 @@
+import type { GlobalAttributes } from "../../../base/global-attributes";
+
+/**
+ * main要素の属性定義
+ * HTML5のmain要素で使用可能な全ての属性を含む
+ */
+export type MainAttributes = GlobalAttributes;

--- a/src/converter/elements/container/main/main-element/__tests__/main-element.accessors.test.ts
+++ b/src/converter/elements/container/main/main-element/__tests__/main-element.accessors.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { MainElement } from "../main-element";
+import type { MainElement as MainElementType } from "../main-element";
+import type { HTMLNode } from "../../../../../models/html-node";
+
+describe("MainElement アクセサメソッド", () => {
+  describe("getId", () => {
+    it("id属性を取得できること", () => {
+      const element = MainElement.create({ id: "main-content" });
+      expect(MainElement.getId(element)).toBe("main-content");
+    });
+
+    it("id属性がない場合undefinedを返すこと", () => {
+      const element = MainElement.create();
+      expect(MainElement.getId(element)).toBeUndefined();
+    });
+  });
+
+  describe("getClassName", () => {
+    it("className属性を取得できること", () => {
+      const element = MainElement.create({ className: "main container" });
+      expect(MainElement.getClassName(element)).toBe("main container");
+    });
+
+    it("className属性がない場合undefinedを返すこと", () => {
+      const element = MainElement.create();
+      expect(MainElement.getClassName(element)).toBeUndefined();
+    });
+  });
+
+  describe("getStyle", () => {
+    it("style属性を取得できること", () => {
+      const element = MainElement.create({ style: "padding: 20px;" });
+      expect(MainElement.getStyle(element)).toBe("padding: 20px;");
+    });
+
+    it("style属性がない場合undefinedを返すこと", () => {
+      const element = MainElement.create();
+      expect(MainElement.getStyle(element)).toBeUndefined();
+    });
+  });
+
+  describe("getAttribute", () => {
+    it("任意の属性を取得できること", () => {
+      const element = MainElement.create({
+        id: "main",
+        className: "content",
+        title: "メインエリア",
+        "data-page": "home",
+        "aria-label": "メインコンテンツ",
+      });
+
+      expect(MainElement.getAttribute(element, "id")).toBe("main");
+      expect(MainElement.getAttribute(element, "className")).toBe("content");
+      expect(MainElement.getAttribute(element, "title")).toBe("メインエリア");
+      expect(MainElement.getAttribute(element, "data-page")).toBe("home");
+      expect(MainElement.getAttribute(element, "aria-label")).toBe(
+        "メインコンテンツ",
+      );
+    });
+
+    it("存在しない属性の場合undefinedを返すこと", () => {
+      const element = MainElement.create({ id: "main" });
+      expect(MainElement.getAttribute(element, "className")).toBeUndefined();
+      expect(MainElement.getAttribute(element, "style")).toBeUndefined();
+      expect(MainElement.getAttribute(element, "data-test")).toBeUndefined();
+    });
+  });
+
+  describe("getChildren", () => {
+    it("子要素を取得できること", () => {
+      const children: HTMLNode[] = [
+        { type: "text", content: "テキスト" },
+        {
+          type: "element",
+          tagName: "section",
+          attributes: {},
+          children: [],
+        },
+      ];
+      const element = MainElement.create({}, children);
+      expect(MainElement.getChildren(element)).toEqual(children);
+    });
+
+    it("子要素がない場合空配列を返すこと", () => {
+      const element = MainElement.create();
+      expect(MainElement.getChildren(element)).toEqual([]);
+    });
+
+    it("子要素が明示的にundefinedの場合undefinedを返すこと", () => {
+      const element: MainElementType = {
+        type: "element",
+        tagName: "main",
+        attributes: {},
+        children: undefined,
+      };
+      expect(MainElement.getChildren(element)).toBeUndefined();
+    });
+  });
+
+  describe("hasAttribute", () => {
+    it("属性が存在する場合trueを返すこと", () => {
+      const element = MainElement.create({
+        id: "main",
+        className: "content",
+        style: "padding: 20px;",
+        "data-page": "home",
+      });
+
+      expect(MainElement.hasAttribute(element, "id")).toBe(true);
+      expect(MainElement.hasAttribute(element, "className")).toBe(true);
+      expect(MainElement.hasAttribute(element, "style")).toBe(true);
+      expect(MainElement.hasAttribute(element, "data-page")).toBe(true);
+    });
+
+    it("属性が存在しない場合falseを返すこと", () => {
+      const element = MainElement.create({ id: "main" });
+
+      expect(MainElement.hasAttribute(element, "className")).toBe(false);
+      expect(MainElement.hasAttribute(element, "style")).toBe(false);
+      expect(MainElement.hasAttribute(element, "title")).toBe(false);
+      expect(MainElement.hasAttribute(element, "data-test")).toBe(false);
+    });
+
+    it("値がundefinedでも属性キーが存在すればtrueを返すこと", () => {
+      const element = MainElement.create({
+        id: undefined as unknown as string,
+      });
+
+      expect(MainElement.hasAttribute(element, "id")).toBe(true);
+    });
+  });
+});

--- a/src/converter/elements/container/main/main-element/__tests__/main-element.factory.test.ts
+++ b/src/converter/elements/container/main/main-element/__tests__/main-element.factory.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { MainElement } from "../main-element";
+import type { MainAttributes } from "../../main-attributes";
+import type { HTMLNode } from "../../../../../models/html-node";
+
+describe("MainElement.create", () => {
+  it("デフォルトのmain要素を作成できること", () => {
+    const element = MainElement.create();
+
+    expect(element).toEqual({
+      type: "element",
+      tagName: "main",
+      attributes: {},
+      children: [],
+    });
+  });
+
+  it("属性を指定してmain要素を作成できること", () => {
+    const attributes: Partial<MainAttributes> = {
+      id: "main-content",
+      className: "main container",
+      style: "padding: 20px;",
+    };
+
+    const element = MainElement.create(attributes);
+
+    expect(element).toEqual({
+      type: "element",
+      tagName: "main",
+      attributes,
+      children: [],
+    });
+  });
+
+  it("子要素を指定してmain要素を作成できること", () => {
+    const children: HTMLNode[] = [
+      {
+        type: "element",
+        tagName: "h1",
+        attributes: {},
+        children: [{ type: "text", content: "タイトル" }],
+      },
+      {
+        type: "element",
+        tagName: "p",
+        attributes: {},
+        children: [{ type: "text", content: "本文" }],
+      },
+    ];
+
+    const element = MainElement.create({}, children);
+
+    expect(element).toEqual({
+      type: "element",
+      tagName: "main",
+      attributes: {},
+      children,
+    });
+  });
+
+  it("属性と子要素を同時に指定してmain要素を作成できること", () => {
+    const attributes: Partial<MainAttributes> = {
+      id: "content",
+      className: "main-area",
+    };
+    const children: HTMLNode[] = [
+      {
+        type: "element",
+        tagName: "section",
+        attributes: { id: "intro" },
+        children: [],
+      },
+    ];
+
+    const element = MainElement.create(attributes, children);
+
+    expect(element).toEqual({
+      type: "element",
+      tagName: "main",
+      attributes,
+      children,
+    });
+  });
+
+  it("グローバル属性を設定できること", () => {
+    const attributes: Partial<MainAttributes> = {
+      id: "main",
+      className: "content",
+      title: "メインエリア",
+      lang: "ja",
+      dir: "ltr",
+      hidden: false,
+      tabindex: -1,
+      accesskey: "m",
+      contenteditable: "false",
+      spellcheck: false,
+      draggable: false,
+      translate: "yes",
+    };
+
+    const element = MainElement.create(attributes);
+
+    expect(element.attributes).toEqual(attributes);
+  });
+
+  it("data-*属性を設定できること", () => {
+    const attributes: Partial<MainAttributes> = {
+      "data-page": "home",
+      "data-section": "main",
+      "data-theme": "light",
+    };
+
+    const element = MainElement.create(attributes);
+
+    expect(element.attributes).toEqual(attributes);
+  });
+
+  it("aria-*属性を設定できること", () => {
+    const attributes: Partial<MainAttributes> = {
+      "aria-label": "メインコンテンツ",
+      "aria-labelledby": "main-heading",
+      "aria-describedby": "main-description",
+    };
+
+    const element = MainElement.create(attributes);
+
+    expect(element.attributes).toEqual(attributes);
+  });
+});

--- a/src/converter/elements/container/main/main-element/__tests__/main-element.mapToFigma.test.ts
+++ b/src/converter/elements/container/main/main-element/__tests__/main-element.mapToFigma.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi } from "vitest";
+import { MainElement } from "../main-element";
+import { HTMLToFigmaMapper } from "../../../../../mapper";
+import type { FigmaNodeConfig } from "../../../../../models/figma-node";
+import type { HTMLNode } from "../../../../../models/html-node";
+
+vi.mock("../../../../../mapper", () => ({
+  HTMLToFigmaMapper: {
+    mapNode: vi.fn(),
+  },
+}));
+
+describe("MainElement.mapToFigma", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("main要素でない場合nullを返すこと", () => {
+    expect(MainElement.mapToFigma(null)).toBeNull();
+    expect(MainElement.mapToFigma(undefined)).toBeNull();
+    expect(MainElement.mapToFigma("main")).toBeNull();
+    expect(
+      MainElement.mapToFigma({ type: "text", content: "text" }),
+    ).toBeNull();
+    expect(
+      MainElement.mapToFigma({
+        type: "element",
+        tagName: "div",
+        attributes: {},
+      }),
+    ).toBeNull();
+  });
+
+  it("基本的なmain要素をFigmaノードに変換できること", () => {
+    const element = MainElement.create();
+    const result = MainElement.mapToFigma(element);
+
+    expect(result).toMatchObject({
+      type: "FRAME",
+      name: "main",
+      layoutMode: "VERTICAL",
+      children: [],
+    });
+  });
+
+  it("子要素がない場合空配列を設定すること", () => {
+    const element = MainElement.create();
+    const result = MainElement.mapToFigma(element);
+
+    expect(result?.children).toEqual([]);
+  });
+
+  it("子要素を正しく処理すること", () => {
+    const childFigmaNode1: FigmaNodeConfig = {
+      type: "FRAME",
+      name: "section",
+    };
+    const childFigmaNode2: FigmaNodeConfig = {
+      type: "TEXT",
+      name: "text",
+      characters: "Hello",
+    };
+
+    (HTMLToFigmaMapper.mapNode as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(childFigmaNode1)
+      .mockReturnValueOnce(childFigmaNode2);
+
+    const children: HTMLNode[] = [
+      { type: "element", tagName: "section", attributes: {}, children: [] },
+      { type: "text", content: "Hello" },
+    ];
+
+    const element = MainElement.create({}, children);
+    const result = MainElement.mapToFigma(element);
+
+    expect(HTMLToFigmaMapper.mapNode).toHaveBeenCalledTimes(2);
+    expect(HTMLToFigmaMapper.mapNode).toHaveBeenNthCalledWith(1, children[0]);
+    expect(HTMLToFigmaMapper.mapNode).toHaveBeenNthCalledWith(2, children[1]);
+    expect(result?.children).toEqual([childFigmaNode1, childFigmaNode2]);
+  });
+
+  it("nullを返す子要素をフィルタリングすること", () => {
+    const childFigmaNode: FigmaNodeConfig = {
+      type: "FRAME",
+      name: "div",
+    };
+
+    (HTMLToFigmaMapper.mapNode as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(childFigmaNode)
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(childFigmaNode);
+
+    const children: HTMLNode[] = [
+      { type: "element", tagName: "div", attributes: {}, children: [] },
+      { type: "comment", content: "comment" },
+      { type: "element", tagName: "div", attributes: {}, children: [] },
+    ];
+
+    const element = MainElement.create({}, children);
+    const result = MainElement.mapToFigma(element);
+
+    expect(HTMLToFigmaMapper.mapNode).toHaveBeenCalledTimes(3);
+    expect(result?.children).toEqual([childFigmaNode, childFigmaNode]);
+  });
+
+  it("属性とスタイルが正しく適用されること", () => {
+    const element = MainElement.create({
+      id: "main-content",
+      className: "main container",
+      style: "display: flex; padding: 20px; background-color: #f5f5f5;",
+    });
+
+    const result = MainElement.mapToFigma(element);
+
+    expect(result).toMatchObject({
+      type: "FRAME",
+      name: "main#main-content.main.container",
+      layoutMode: "HORIZONTAL",
+      paddingTop: 20,
+      paddingRight: 20,
+      paddingBottom: 20,
+      paddingLeft: 20,
+    });
+
+    expect(result?.fills).toBeDefined();
+    expect(result?.fills).toHaveLength(1);
+  });
+
+  it("複雑な子要素構造を持つmain要素を正しく処理すること", () => {
+    const nestedChildFigmaNode: FigmaNodeConfig = {
+      type: "FRAME",
+      name: "article",
+    };
+    const textFigmaNode: FigmaNodeConfig = {
+      type: "TEXT",
+      name: "text",
+      characters: "Content",
+    };
+
+    (HTMLToFigmaMapper.mapNode as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(nestedChildFigmaNode)
+      .mockReturnValueOnce(textFigmaNode)
+      .mockReturnValueOnce(null);
+
+    const children: HTMLNode[] = [
+      {
+        type: "element",
+        tagName: "article",
+        attributes: { id: "article1" },
+        children: [{ type: "text", content: "Article content" }],
+      },
+      { type: "text", content: "Content" },
+      { type: "comment", content: "This is a comment" },
+    ];
+
+    const element = MainElement.create(
+      { id: "main", style: "padding: 16px;" },
+      children,
+    );
+    const result = MainElement.mapToFigma(element);
+
+    expect(HTMLToFigmaMapper.mapNode).toHaveBeenCalledTimes(3);
+    expect(result).toMatchObject({
+      type: "FRAME",
+      name: "main#main",
+      paddingTop: 16,
+      paddingRight: 16,
+      paddingBottom: 16,
+      paddingLeft: 16,
+      children: [nestedChildFigmaNode, textFigmaNode],
+    });
+  });
+
+  it("子要素がundefinedの場合空配列を設定すること", () => {
+    const element = {
+      type: "element" as const,
+      tagName: "main" as const,
+      attributes: {},
+      children: undefined,
+    };
+
+    const result = MainElement.mapToFigma(element);
+    expect(result?.children).toEqual([]);
+    expect(HTMLToFigmaMapper.mapNode).not.toHaveBeenCalled();
+  });
+});

--- a/src/converter/elements/container/main/main-element/__tests__/main-element.toFigmaNode.test.ts
+++ b/src/converter/elements/container/main/main-element/__tests__/main-element.toFigmaNode.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from "vitest";
+import { MainElement } from "../main-element";
+
+describe("MainElement.toFigmaNode", () => {
+  it("基本的なmain要素をFigmaノードに変換できること", () => {
+    const element = MainElement.create();
+    const figmaNode = MainElement.toFigmaNode(element);
+
+    expect(figmaNode).toEqual({
+      type: "FRAME",
+      name: "main",
+      layoutMode: "VERTICAL",
+      layoutSizingVertical: "HUG",
+      layoutSizingHorizontal: "FIXED",
+      paddingLeft: 0,
+      paddingRight: 0,
+      paddingTop: 0,
+      paddingBottom: 0,
+      itemSpacing: 0,
+    });
+  });
+
+  it("id属性を持つmain要素の名前が正しく生成されること", () => {
+    const element = MainElement.create({ id: "main-content" });
+    const figmaNode = MainElement.toFigmaNode(element);
+
+    expect(figmaNode.name).toBe("main#main-content");
+  });
+
+  it("className属性を持つmain要素の名前が正しく生成されること", () => {
+    const element = MainElement.create({ className: "main container" });
+    const figmaNode = MainElement.toFigmaNode(element);
+
+    expect(figmaNode.name).toBe("main.main.container");
+  });
+
+  it("idとclassNameを両方持つmain要素の名前が正しく生成されること", () => {
+    const element = MainElement.create({
+      id: "content",
+      className: "main-area responsive",
+    });
+    const figmaNode = MainElement.toFigmaNode(element);
+
+    expect(figmaNode.name).toBe("main#content.main-area.responsive");
+  });
+
+  it("display:flexスタイルが適用されること", () => {
+    const element = MainElement.create({
+      style:
+        "display: flex; flex-direction: row; justify-content: center; align-items: center;",
+    });
+    const figmaNode = MainElement.toFigmaNode(element);
+
+    expect(figmaNode.layoutMode).toBe("HORIZONTAL");
+    expect(figmaNode.primaryAxisAlignItems).toBe("CENTER");
+    expect(figmaNode.counterAxisAlignItems).toBe("CENTER");
+  });
+
+  it("パディングスタイルが適用されること", () => {
+    const element = MainElement.create({
+      style: "padding: 20px;",
+    });
+    const figmaNode = MainElement.toFigmaNode(element);
+
+    expect(figmaNode.paddingTop).toBe(20);
+    expect(figmaNode.paddingRight).toBe(20);
+    expect(figmaNode.paddingBottom).toBe(20);
+    expect(figmaNode.paddingLeft).toBe(20);
+  });
+
+  it("個別のパディングスタイルが適用されること", () => {
+    const element = MainElement.create({
+      style:
+        "padding-top: 10px; padding-right: 20px; padding-bottom: 30px; padding-left: 40px;",
+    });
+    const figmaNode = MainElement.toFigmaNode(element);
+
+    expect(figmaNode.paddingTop).toBe(10);
+    expect(figmaNode.paddingRight).toBe(20);
+    expect(figmaNode.paddingBottom).toBe(30);
+    expect(figmaNode.paddingLeft).toBe(40);
+  });
+
+  it("gapスタイルが適用されること", () => {
+    const element = MainElement.create({
+      style: "display: flex; gap: 16px;",
+    });
+    const figmaNode = MainElement.toFigmaNode(element);
+
+    expect(figmaNode.itemSpacing).toBe(16);
+  });
+
+  it("背景色が適用されること", () => {
+    const element = MainElement.create({
+      style: "background-color: #f0f0f0;",
+    });
+    const figmaNode = MainElement.toFigmaNode(element);
+
+    expect(figmaNode.fills).toEqual([
+      {
+        type: "SOLID",
+        color: {
+          r: 0.9411764705882353,
+          g: 0.9411764705882353,
+          b: 0.9411764705882353,
+        },
+        opacity: 1,
+      },
+    ]);
+  });
+
+  it("サイズスタイルが適用されること", () => {
+    const element = MainElement.create({
+      style: "width: 1200px; height: 800px;",
+    });
+    const figmaNode = MainElement.toFigmaNode(element);
+
+    expect(figmaNode.width).toBe(1200);
+    expect(figmaNode.layoutSizingHorizontal).toBe("FIXED");
+    expect(figmaNode.height).toBe(800);
+    expect(figmaNode.layoutSizingVertical).toBe("FIXED");
+  });
+
+  it("最小・最大サイズスタイルが適用されること", () => {
+    const element = MainElement.create({
+      style:
+        "min-width: 320px; max-width: 1920px; min-height: 480px; max-height: 1080px;",
+    });
+    const figmaNode = MainElement.toFigmaNode(element);
+
+    expect((figmaNode as Record<string, unknown>).minWidth).toBe(320);
+    expect((figmaNode as Record<string, unknown>).maxWidth).toBe(1920);
+    expect((figmaNode as Record<string, unknown>).minHeight).toBe(480);
+    expect((figmaNode as Record<string, unknown>).maxHeight).toBe(1080);
+  });
+
+  it("Flexbox justify-contentの全バリエーションが正しくマッピングされること", () => {
+    const justifyContentMap = {
+      "flex-start": "MIN",
+      "flex-end": "MAX",
+      center: "CENTER",
+      "space-between": "SPACE_BETWEEN",
+      "space-around": "SPACE_AROUND",
+      "space-evenly": "SPACE_EVENLY",
+    };
+
+    Object.entries(justifyContentMap).forEach(([cssValue, figmaValue]) => {
+      const element = MainElement.create({
+        style: `display: flex; justify-content: ${cssValue};`,
+      });
+      const figmaNode = MainElement.toFigmaNode(element);
+      expect(figmaNode.primaryAxisAlignItems).toBe(figmaValue);
+    });
+  });
+
+  it("Flexbox align-itemsの全バリエーションが正しくマッピングされること", () => {
+    const alignItemsMap = {
+      "flex-start": "MIN",
+      "flex-end": "MAX",
+      center: "CENTER",
+      stretch: "STRETCH",
+      baseline: "BASELINE",
+    };
+
+    Object.entries(alignItemsMap).forEach(([cssValue, figmaValue]) => {
+      const element = MainElement.create({
+        style: `display: flex; align-items: ${cssValue};`,
+      });
+      const figmaNode = MainElement.toFigmaNode(element);
+      expect(figmaNode.counterAxisAlignItems).toBe(figmaValue);
+    });
+  });
+
+  it("複数のスタイルが同時に適用されること", () => {
+    const element = MainElement.create({
+      id: "main",
+      className: "content-area",
+      style:
+        "display: flex; flex-direction: column; justify-content: space-between; align-items: stretch; padding: 24px; gap: 16px; background-color: white; width: 100%; min-height: 600px;",
+    });
+    const figmaNode = MainElement.toFigmaNode(element);
+
+    expect(figmaNode).toMatchObject({
+      type: "FRAME",
+      name: "main#main.content-area",
+      layoutMode: "VERTICAL",
+      primaryAxisAlignItems: "SPACE_BETWEEN",
+      counterAxisAlignItems: "STRETCH",
+      paddingTop: 24,
+      paddingRight: 24,
+      paddingBottom: 24,
+      paddingLeft: 24,
+      itemSpacing: 16,
+      width: 100,
+      layoutSizingHorizontal: "FIXED",
+      fills: [
+        {
+          type: "SOLID",
+          color: { r: 1, g: 1, b: 1 },
+          opacity: 1,
+        },
+      ],
+    });
+    expect((figmaNode as Record<string, unknown>).minHeight).toBe(600);
+  });
+});

--- a/src/converter/elements/container/main/main-element/__tests__/main-element.typeguards.test.ts
+++ b/src/converter/elements/container/main/main-element/__tests__/main-element.typeguards.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { MainElement } from "../main-element";
+
+describe("MainElement.isMainElement", () => {
+  it("main要素の場合trueを返すこと", () => {
+    const element = {
+      type: "element",
+      tagName: "main",
+      attributes: {},
+    };
+
+    expect(MainElement.isMainElement(element)).toBe(true);
+  });
+
+  it("type='element'でない場合falseを返すこと", () => {
+    const element = {
+      type: "text",
+      tagName: "main",
+      attributes: {},
+    };
+
+    expect(MainElement.isMainElement(element)).toBe(false);
+  });
+
+  it("tagName='main'でない場合falseを返すこと", () => {
+    const element = {
+      type: "element",
+      tagName: "div",
+      attributes: {},
+    };
+
+    expect(MainElement.isMainElement(element)).toBe(false);
+  });
+
+  it("nullの場合falseを返すこと", () => {
+    expect(MainElement.isMainElement(null)).toBe(false);
+  });
+
+  it("undefinedの場合falseを返すこと", () => {
+    expect(MainElement.isMainElement(undefined)).toBe(false);
+  });
+
+  it("オブジェクトでない場合falseを返すこと", () => {
+    expect(MainElement.isMainElement("main")).toBe(false);
+    expect(MainElement.isMainElement(123)).toBe(false);
+    expect(MainElement.isMainElement(true)).toBe(false);
+  });
+
+  it("必要なプロパティが不足している場合falseを返すこと", () => {
+    expect(MainElement.isMainElement({ type: "element" })).toBe(false);
+    expect(MainElement.isMainElement({ tagName: "main" })).toBe(false);
+    expect(MainElement.isMainElement({})).toBe(false);
+  });
+});

--- a/src/converter/elements/container/main/main-element/index.ts
+++ b/src/converter/elements/container/main/main-element/index.ts
@@ -1,0 +1,1 @@
+export { MainElement } from "./main-element";

--- a/src/converter/elements/container/main/main-element/main-element.ts
+++ b/src/converter/elements/container/main/main-element/main-element.ts
@@ -1,0 +1,292 @@
+import type { HTMLNode } from "../../../../models/html-node";
+import type { FigmaNodeConfig } from "../../../../models/figma-node";
+import type { MainAttributes } from "../main-attributes";
+import { Styles } from "../../../../models/styles";
+import { HTMLToFigmaMapper } from "../../../../mapper";
+
+/**
+ * main要素の型定義
+ * HTML5のmain要素を表現し、Figmaのフレームノードに変換される
+ */
+export interface MainElement {
+  type: "element";
+  tagName: "main";
+  attributes: MainAttributes;
+  children?: HTMLNode[];
+}
+
+/**
+ * main要素のコンパニオンオブジェクト
+ * 型ガード、ファクトリー、アクセサ、変換メソッドを提供
+ */
+export const MainElement = {
+  /**
+   * main要素かどうかを判定する型ガード
+   */
+  isMainElement(node: unknown): node is MainElement {
+    return (
+      typeof node === "object" &&
+      node !== null &&
+      "type" in node &&
+      node.type === "element" &&
+      "tagName" in node &&
+      node.tagName === "main"
+    );
+  },
+
+  /**
+   * main要素を作成するファクトリー関数
+   */
+  create(
+    attributes: Partial<MainAttributes> = {},
+    children: HTMLNode[] = [],
+  ): MainElement {
+    return {
+      type: "element",
+      tagName: "main",
+      attributes: attributes as MainAttributes,
+      children,
+    };
+  },
+
+  /**
+   * ID属性を取得
+   */
+  getId(element: MainElement): string | undefined {
+    return element.attributes.id;
+  },
+
+  /**
+   * className属性を取得
+   */
+  getClassName(element: MainElement): string | undefined {
+    return element.attributes.className;
+  },
+
+  /**
+   * style属性を取得
+   */
+  getStyle(element: MainElement): string | undefined {
+    return element.attributes.style;
+  },
+
+  /**
+   * 任意の属性を取得
+   */
+  getAttribute(element: MainElement, name: string): unknown {
+    return element.attributes[name as keyof MainAttributes];
+  },
+
+  /**
+   * 子要素を取得
+   */
+  getChildren(element: MainElement): HTMLNode[] | undefined {
+    return element.children;
+  },
+
+  /**
+   * 属性の存在確認
+   */
+  hasAttribute(element: MainElement, name: string): boolean {
+    return name in element.attributes;
+  },
+
+  /**
+   * main要素をFigmaノードに変換
+   */
+  toFigmaNode(element: MainElement): FigmaNodeConfig {
+    const { id, className, style } = element.attributes;
+    const styles = Styles.parse(style || "");
+
+    // ノード名の生成
+    let name = "main";
+    if (id) {
+      name += `#${id}`;
+    }
+    if (className) {
+      const classes = className.split(" ").filter(Boolean);
+      if (classes.length > 0) {
+        name += `.${classes.join(".")}`;
+      }
+    }
+
+    // 基本設定（デフォルトは縦方向のレイアウト）
+    const figmaNode: FigmaNodeConfig = {
+      type: "FRAME",
+      name,
+      layoutMode: "VERTICAL",
+      layoutSizingVertical: "HUG",
+      layoutSizingHorizontal: "FIXED",
+      paddingLeft: 0,
+      paddingRight: 0,
+      paddingTop: 0,
+      paddingBottom: 0,
+      itemSpacing: 0,
+    };
+
+    // display: flexの処理
+    if (styles.display === "flex") {
+      // Flexbox設定
+      // CSSのデフォルトはflex-direction: row
+      const flexDirection = styles["flex-direction"] || "row";
+      figmaNode.layoutMode =
+        flexDirection === "row" ? "HORIZONTAL" : "VERTICAL";
+
+      // justify-content
+      const justifyContent = styles["justify-content"];
+      if (justifyContent) {
+        const alignMap: Record<string, string> = {
+          "flex-start": "MIN",
+          "flex-end": "MAX",
+          center: "CENTER",
+          "space-between": "SPACE_BETWEEN",
+          "space-around": "SPACE_AROUND",
+          "space-evenly": "SPACE_EVENLY",
+        };
+        figmaNode.primaryAxisAlignItems = (alignMap[justifyContent] ||
+          "MIN") as "MIN" | "CENTER" | "MAX" | "SPACE_BETWEEN";
+      }
+
+      // align-items
+      const alignItems = styles["align-items"];
+      if (alignItems) {
+        const alignMap: Record<string, string> = {
+          "flex-start": "MIN",
+          "flex-end": "MAX",
+          center: "CENTER",
+          stretch: "STRETCH",
+          baseline: "BASELINE",
+        };
+        figmaNode.counterAxisAlignItems = (alignMap[alignItems] || "MIN") as
+          | "MIN"
+          | "CENTER"
+          | "MAX"
+          | "STRETCH";
+      }
+    }
+
+    // パディング処理
+    if (styles.padding) {
+      const paddingValue = parseFloat(styles.padding);
+      if (!isNaN(paddingValue)) {
+        figmaNode.paddingTop = paddingValue;
+        figmaNode.paddingRight = paddingValue;
+        figmaNode.paddingBottom = paddingValue;
+        figmaNode.paddingLeft = paddingValue;
+      }
+    }
+
+    // 個別パディング
+    ["top", "right", "bottom", "left"].forEach((side) => {
+      const key = `padding-${side}` as keyof typeof styles;
+      const figmaKey = `padding${
+        side.charAt(0).toUpperCase() + side.slice(1)
+      }` as keyof FigmaNodeConfig;
+      if (styles[key]) {
+        const value = parseFloat(styles[key] as string);
+        if (!isNaN(value)) {
+          (figmaNode as unknown as Record<string, unknown>)[figmaKey] = value;
+        }
+      }
+    });
+
+    // ギャップ（itemSpacing）
+    if (styles.gap) {
+      const gapValue = parseFloat(styles.gap);
+      if (!isNaN(gapValue)) {
+        figmaNode.itemSpacing = gapValue;
+      }
+    }
+
+    // 背景色
+    if (styles["background-color"]) {
+      const color = styles["background-color"];
+      let r = 0,
+        g = 0,
+        b = 0;
+      const opacity = 1;
+
+      if (color.startsWith("#")) {
+        const hex = color.slice(1);
+        if (hex.length === 3) {
+          r = parseInt(hex[0] + hex[0], 16) / 255;
+          g = parseInt(hex[1] + hex[1], 16) / 255;
+          b = parseInt(hex[2] + hex[2], 16) / 255;
+        } else if (hex.length === 6) {
+          r = parseInt(hex.slice(0, 2), 16) / 255;
+          g = parseInt(hex.slice(2, 4), 16) / 255;
+          b = parseInt(hex.slice(4, 6), 16) / 255;
+        }
+      } else if (color === "white") {
+        r = g = b = 1;
+      } else if (color === "black") {
+        r = g = b = 0;
+      }
+
+      figmaNode.fills = [
+        {
+          type: "SOLID",
+          color: { r, g, b },
+          opacity,
+        },
+      ];
+    }
+
+    // サイズ設定
+    if (styles.width) {
+      const width = parseFloat(styles.width);
+      if (!isNaN(width)) {
+        figmaNode.width = width;
+        figmaNode.layoutSizingHorizontal = "FIXED";
+      }
+    }
+
+    if (styles.height) {
+      const height = parseFloat(styles.height);
+      if (!isNaN(height)) {
+        figmaNode.height = height;
+        figmaNode.layoutSizingVertical = "FIXED";
+      }
+    }
+
+    // 最小・最大サイズ
+    ["min-width", "max-width", "min-height", "max-height"].forEach((prop) => {
+      if (styles[prop]) {
+        const value = parseFloat(styles[prop]);
+        if (!isNaN(value)) {
+          const figmaKey = prop.replace("-", "") as keyof FigmaNodeConfig;
+          const camelCaseKey =
+            figmaKey.slice(0, 3) +
+            figmaKey.charAt(3).toUpperCase() +
+            figmaKey.slice(4);
+          (figmaNode as unknown as Record<string, unknown>)[camelCaseKey] =
+            value;
+        }
+      }
+    });
+
+    return figmaNode;
+  },
+
+  /**
+   * HTMLノードをFigmaノードにマッピング
+   */
+  mapToFigma(node: unknown): FigmaNodeConfig | null {
+    if (!MainElement.isMainElement(node)) {
+      return null;
+    }
+
+    const figmaNode = MainElement.toFigmaNode(node);
+
+    // 子要素の処理
+    if (node.children && node.children.length > 0) {
+      figmaNode.children = node.children
+        .map((child) => HTMLToFigmaMapper.mapNode(child))
+        .filter((child): child is FigmaNodeConfig => child !== null);
+    } else {
+      figmaNode.children = [];
+    }
+
+    return figmaNode;
+  },
+};


### PR DESCRIPTION
## 📋 概要
HTML5の`<main>`要素をFigmaのフレームノードに変換する機能を実装しました。

## 🎯 実装内容
- **main要素の完全な型定義とコンバーター実装**
  - GlobalAttributesを継承した属性定義
  - MainElementインターフェース
  - コンパニオンオブジェクトパターンによる実装

## ✨ 主な機能
- **型安全な要素変換**
  - 型ガード (`isMainElement`)
  - ファクトリー関数 (`create`)
  - アクセサメソッド (`getId`, `getClassName`, `getStyle`等)
  
- **Figmaノードへの変換**
  - Flexboxレイアウトのサポート
  - パディング、ギャップの適用
  - 背景色の変換
  - サイズ設定（width, height, min/max）

## 🧪 テスト
- **TDD（テスト駆動開発）による実装**
- **55個のテストケース全てパス**
  - 型ガードテスト
  - ファクトリーテスト
  - アクセサテスト
  - Figma変換テスト
  - マッピングテスト

## 📁 ファイル構成
```
src/converter/elements/container/main/
├── main-attributes/
│   ├── __tests__/
│   │   └── main-attributes.test.ts
│   ├── main-attributes.ts
│   └── index.ts
├── main-element/
│   ├── __tests__/
│   │   ├── main-element.typeguards.test.ts
│   │   ├── main-element.factory.test.ts
│   │   ├── main-element.accessors.test.ts
│   │   ├── main-element.toFigmaNode.test.ts
│   │   └── main-element.mapToFigma.test.ts
│   ├── main-element.ts
│   └── index.ts
└── index.ts
```

## ✅ チェックリスト
- [x] テスト全てパス (55個)
- [x] Lintチェックパス
- [x] 型チェックパス
- [x] 既存のコードスタイルに準拠
- [x] docs/html-elements-refactoring/plan.md のフェーズ2実装完了

## 📝 備考
article要素の実装パターンに従い、同じ品質基準で実装しています。
CSSのflexboxデフォルト値（flex-direction: row）も正しく反映しています。

🤖 Generated with [Claude Code](https://claude.ai/code)