### PR TITLE
✨ HTML5 footer要素のFigma変換機能を追加

### DIFF
--- a/src/converter/elements/container/footer/footer-attributes/__tests__/footer-attributes.test.ts
+++ b/src/converter/elements/container/footer/footer-attributes/__tests__/footer-attributes.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expectTypeOf } from "vitest";
+import type { FooterAttributes } from "../footer-attributes";
+import type { GlobalAttributes } from "../../../../base/global-attributes";
+
+describe("FooterAttributes", () => {
+  it("GlobalAttributesを継承していること", () => {
+    expectTypeOf<FooterAttributes>().toEqualTypeOf<GlobalAttributes>();
+  });
+
+  it("id属性を持つこと", () => {
+    const attrs: FooterAttributes = { id: "footer" };
+    expectTypeOf(attrs.id).toEqualTypeOf<string | undefined>();
+  });
+
+  it("className属性を持つこと", () => {
+    const attrs: FooterAttributes = { className: "footer" };
+    expectTypeOf(attrs.className).toEqualTypeOf<string | undefined>();
+  });
+
+  it("style属性を持つこと", () => {
+    const attrs: FooterAttributes = { style: "padding: 10px;" };
+    expectTypeOf(attrs.style).toEqualTypeOf<string | undefined>();
+  });
+
+  it("data-*属性を持つこと", () => {
+    const attrs: FooterAttributes = {
+      "data-test": "value",
+      "data-id": "123",
+    };
+    expectTypeOf(attrs["data-test"]).toEqualTypeOf<string | undefined>();
+  });
+
+  it("aria-*属性を持つこと", () => {
+    const attrs: FooterAttributes = {
+      "aria-label": "フッター",
+      "aria-labelledby": "footer-heading",
+    };
+    expectTypeOf(attrs["aria-label"]).toEqualTypeOf<string | undefined>();
+  });
+});

--- a/src/converter/elements/container/footer/footer-attributes/footer-attributes.ts
+++ b/src/converter/elements/container/footer/footer-attributes/footer-attributes.ts
@@ -1,0 +1,7 @@
+import type { GlobalAttributes } from "../../../base/global-attributes";
+
+/**
+ * footer要素の属性定義
+ * HTML5のfooter要素で使用可能な全ての属性を含む
+ */
+export type FooterAttributes = GlobalAttributes;

--- a/src/converter/elements/container/footer/footer-attributes/index.ts
+++ b/src/converter/elements/container/footer/footer-attributes/index.ts
@@ -1,0 +1,1 @@
+export type { FooterAttributes } from "./footer-attributes";

--- a/src/converter/elements/container/footer/footer-element/__tests__/footer-element.accessors.test.ts
+++ b/src/converter/elements/container/footer/footer-element/__tests__/footer-element.accessors.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from "vitest";
+import { FooterElement } from "../footer-element";
+import type { FooterElement as FooterElementType } from "../footer-element";
+
+describe("FooterElement Accessors", () => {
+  describe("getId", () => {
+    it("ID属性を取得できること", () => {
+      const element: FooterElementType = {
+        type: "element",
+        tagName: "footer",
+        attributes: { id: "site-footer" },
+      };
+
+      expect(FooterElement.getId(element)).toBe("site-footer");
+    });
+
+    it("ID属性がない場合はundefinedを返すこと", () => {
+      const element: FooterElementType = {
+        type: "element",
+        tagName: "footer",
+        attributes: {},
+      };
+
+      expect(FooterElement.getId(element)).toBeUndefined();
+    });
+  });
+
+  describe("getClassName", () => {
+    it("className属性を取得できること", () => {
+      const element: FooterElementType = {
+        type: "element",
+        tagName: "footer",
+        attributes: { className: "footer site-footer" },
+      };
+
+      expect(FooterElement.getClassName(element)).toBe("footer site-footer");
+    });
+
+    it("className属性がない場合はundefinedを返すこと", () => {
+      const element: FooterElementType = {
+        type: "element",
+        tagName: "footer",
+        attributes: {},
+      };
+
+      expect(FooterElement.getClassName(element)).toBeUndefined();
+    });
+  });
+
+  describe("getStyle", () => {
+    it("style属性を取得できること", () => {
+      const element: FooterElementType = {
+        type: "element",
+        tagName: "footer",
+        attributes: { style: "background-color: #333; padding: 20px;" },
+      };
+
+      expect(FooterElement.getStyle(element)).toBe(
+        "background-color: #333; padding: 20px;",
+      );
+    });
+
+    it("style属性がない場合はundefinedを返すこと", () => {
+      const element: FooterElementType = {
+        type: "element",
+        tagName: "footer",
+        attributes: {},
+      };
+
+      expect(FooterElement.getStyle(element)).toBeUndefined();
+    });
+  });
+
+  describe("getAttribute", () => {
+    it("指定された属性を取得できること", () => {
+      const element: FooterElementType = {
+        type: "element",
+        tagName: "footer",
+        attributes: {
+          id: "footer",
+          className: "site-footer",
+          "data-theme": "dark",
+          "aria-label": "ページフッター",
+        },
+      };
+
+      expect(FooterElement.getAttribute(element, "id")).toBe("footer");
+      expect(FooterElement.getAttribute(element, "className")).toBe(
+        "site-footer",
+      );
+      expect(FooterElement.getAttribute(element, "data-theme")).toBe("dark");
+      expect(FooterElement.getAttribute(element, "aria-label")).toBe(
+        "ページフッター",
+      );
+    });
+
+    it("存在しない属性の場合はundefinedを返すこと", () => {
+      const element: FooterElementType = {
+        type: "element",
+        tagName: "footer",
+        attributes: { id: "footer" },
+      };
+
+      expect(FooterElement.getAttribute(element, "className")).toBeUndefined();
+      expect(FooterElement.getAttribute(element, "style")).toBeUndefined();
+    });
+  });
+
+  describe("getChildren", () => {
+    it("子要素を取得できること", () => {
+      const children = [
+        { type: "text" as const, content: "Footer content" },
+        {
+          type: "element" as const,
+          tagName: "nav",
+          attributes: {},
+          children: [],
+        },
+      ];
+      const element: FooterElementType = {
+        type: "element",
+        tagName: "footer",
+        attributes: {},
+        children,
+      };
+
+      expect(FooterElement.getChildren(element)).toEqual(children);
+    });
+
+    it("子要素がない場合はundefinedを返すこと", () => {
+      const element: FooterElementType = {
+        type: "element",
+        tagName: "footer",
+        attributes: {},
+      };
+
+      expect(FooterElement.getChildren(element)).toBeUndefined();
+    });
+
+    it("空の子要素配列の場合は空配列を返すこと", () => {
+      const element: FooterElementType = {
+        type: "element",
+        tagName: "footer",
+        attributes: {},
+        children: [],
+      };
+
+      expect(FooterElement.getChildren(element)).toEqual([]);
+    });
+  });
+
+  describe("hasAttribute", () => {
+    it("存在する属性の場合はtrueを返すこと", () => {
+      const element: FooterElementType = {
+        type: "element",
+        tagName: "footer",
+        attributes: {
+          id: "footer",
+          className: "site-footer",
+          style: "padding: 10px;",
+        },
+      };
+
+      expect(FooterElement.hasAttribute(element, "id")).toBe(true);
+      expect(FooterElement.hasAttribute(element, "className")).toBe(true);
+      expect(FooterElement.hasAttribute(element, "style")).toBe(true);
+    });
+
+    it("存在しない属性の場合はfalseを返すこと", () => {
+      const element: FooterElementType = {
+        type: "element",
+        tagName: "footer",
+        attributes: { id: "footer" },
+      };
+
+      expect(FooterElement.hasAttribute(element, "className")).toBe(false);
+      expect(FooterElement.hasAttribute(element, "style")).toBe(false);
+      expect(FooterElement.hasAttribute(element, "data-test")).toBe(false);
+    });
+
+    it("値がundefinedでも属性が存在すればtrueを返すこと", () => {
+      const element: FooterElementType = {
+        type: "element",
+        tagName: "footer",
+        attributes: { id: undefined } as FooterElementType["attributes"],
+      };
+
+      expect(FooterElement.hasAttribute(element, "id")).toBe(true);
+    });
+  });
+});

--- a/src/converter/elements/container/footer/footer-element/__tests__/footer-element.factory.test.ts
+++ b/src/converter/elements/container/footer/footer-element/__tests__/footer-element.factory.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { FooterElement } from "../footer-element";
+import type { FooterAttributes } from "../../footer-attributes";
+import type { HTMLNode } from "../../../../../models/html-node";
+
+describe("FooterElement.create", () => {
+  it("デフォルトのfooter要素を作成できること", () => {
+    const element = FooterElement.create();
+
+    expect(element).toEqual({
+      type: "element",
+      tagName: "footer",
+      attributes: {},
+      children: [],
+    });
+  });
+
+  it("属性を指定してfooter要素を作成できること", () => {
+    const attributes: Partial<FooterAttributes> = {
+      id: "page-footer",
+      className: "footer container",
+      style: "background-color: #f5f5f5;",
+    };
+
+    const element = FooterElement.create(attributes);
+
+    expect(element).toEqual({
+      type: "element",
+      tagName: "footer",
+      attributes,
+      children: [],
+    });
+  });
+
+  it("子要素を指定してfooter要素を作成できること", () => {
+    const children: HTMLNode[] = [
+      {
+        type: "element",
+        tagName: "p",
+        attributes: {},
+        children: [{ type: "text", content: "© 2024 Company" }],
+      },
+      {
+        type: "element",
+        tagName: "nav",
+        attributes: {},
+        children: [],
+      },
+    ];
+
+    const element = FooterElement.create({}, children);
+
+    expect(element).toEqual({
+      type: "element",
+      tagName: "footer",
+      attributes: {},
+      children,
+    });
+  });
+
+  it("属性と子要素を同時に指定してfooter要素を作成できること", () => {
+    const attributes: Partial<FooterAttributes> = {
+      id: "site-footer",
+      className: "footer-area",
+    };
+    const children: HTMLNode[] = [
+      {
+        type: "element",
+        tagName: "div",
+        attributes: { className: "footer-content" },
+        children: [],
+      },
+    ];
+
+    const element = FooterElement.create(attributes, children);
+
+    expect(element).toEqual({
+      type: "element",
+      tagName: "footer",
+      attributes,
+      children,
+    });
+  });
+
+  it("グローバル属性を設定できること", () => {
+    const attributes: Partial<FooterAttributes> = {
+      id: "footer",
+      className: "site-footer",
+      title: "フッターエリア",
+      lang: "ja",
+      dir: "ltr",
+      hidden: false,
+      tabindex: -1,
+      accesskey: "f",
+      contenteditable: "false",
+      spellcheck: false,
+      draggable: false,
+      translate: "yes",
+    };
+
+    const element = FooterElement.create(attributes);
+
+    expect(element.attributes).toEqual(attributes);
+  });
+
+  it("data-*属性を設定できること", () => {
+    const attributes: Partial<FooterAttributes> = {
+      "data-section": "footer",
+      "data-theme": "dark",
+      "data-year": "2024",
+    };
+
+    const element = FooterElement.create(attributes);
+
+    expect(element.attributes).toEqual(attributes);
+  });
+
+  it("aria-*属性を設定できること", () => {
+    const attributes: Partial<FooterAttributes> = {
+      "aria-label": "ページフッター",
+      "aria-labelledby": "footer-heading",
+      "aria-describedby": "footer-description",
+    };
+
+    const element = FooterElement.create(attributes);
+
+    expect(element.attributes).toEqual(attributes);
+  });
+});

--- a/src/converter/elements/container/footer/footer-element/__tests__/footer-element.mapToFigma.test.ts
+++ b/src/converter/elements/container/footer/footer-element/__tests__/footer-element.mapToFigma.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { FooterElement } from "../footer-element";
+import { HTMLToFigmaMapper } from "../../../../../mapper";
+
+vi.mock("../../../../../mapper", () => ({
+  HTMLToFigmaMapper: {
+    mapNode: vi.fn(),
+  },
+}));
+
+describe("FooterElement.mapToFigma", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("footer要素でない場合はnullを返すこと", () => {
+    const node = {
+      type: "element",
+      tagName: "div",
+      attributes: {},
+    };
+
+    const result = FooterElement.mapToFigma(node);
+
+    expect(result).toBeNull();
+  });
+
+  it("子要素なしのfooter要素をマッピングできること", () => {
+    const node = {
+      type: "element",
+      tagName: "footer",
+      attributes: { id: "footer" },
+    };
+
+    const result = FooterElement.mapToFigma(node);
+
+    expect(result).toMatchObject({
+      type: "FRAME",
+      name: "footer#footer",
+      layoutMode: "VERTICAL",
+      layoutSizingHorizontal: "FILL",
+      children: [],
+    });
+  });
+
+  it("子要素ありのfooter要素をマッピングできること", () => {
+    const childNode1 = { type: "element", tagName: "p", attributes: {} };
+    const childNode2 = { type: "element", tagName: "nav", attributes: {} };
+    const mappedChild1 = { type: "TEXT", name: "p" };
+    const mappedChild2 = { type: "FRAME", name: "nav" };
+
+    (HTMLToFigmaMapper.mapNode as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(mappedChild1)
+      .mockReturnValueOnce(mappedChild2);
+
+    const node = {
+      type: "element",
+      tagName: "footer",
+      attributes: { className: "site-footer" },
+      children: [childNode1, childNode2],
+    };
+
+    const result = FooterElement.mapToFigma(node);
+
+    expect(HTMLToFigmaMapper.mapNode).toHaveBeenCalledTimes(2);
+    expect(HTMLToFigmaMapper.mapNode).toHaveBeenNthCalledWith(1, childNode1);
+    expect(HTMLToFigmaMapper.mapNode).toHaveBeenNthCalledWith(2, childNode2);
+
+    expect(result).toMatchObject({
+      type: "FRAME",
+      name: "footer.site-footer",
+      layoutMode: "VERTICAL",
+      layoutSizingHorizontal: "FILL",
+      children: [mappedChild1, mappedChild2],
+    });
+  });
+
+  it("nullを返すマッピングをフィルタリングすること", () => {
+    const childNode1 = { type: "element", tagName: "p", attributes: {} };
+    const childNode2 = { type: "comment", content: "comment" };
+    const childNode3 = { type: "element", tagName: "div", attributes: {} };
+    const mappedChild1 = { type: "TEXT", name: "p" };
+    const mappedChild3 = { type: "FRAME", name: "div" };
+
+    (HTMLToFigmaMapper.mapNode as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(mappedChild1)
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(mappedChild3);
+
+    const node = {
+      type: "element",
+      tagName: "footer",
+      attributes: {},
+      children: [childNode1, childNode2, childNode3],
+    };
+
+    const result = FooterElement.mapToFigma(node);
+
+    expect(HTMLToFigmaMapper.mapNode).toHaveBeenCalledTimes(3);
+    expect(result?.children).toEqual([mappedChild1, mappedChild3]);
+  });
+
+  it("スタイル付きのfooter要素をマッピングできること", () => {
+    const node = {
+      type: "element",
+      tagName: "footer",
+      attributes: {
+        id: "footer",
+        className: "footer-container",
+        style: "display: flex; padding: 20px; background-color: #f0f0f0;",
+      },
+      children: [],
+    };
+
+    const result = FooterElement.mapToFigma(node);
+
+    expect(result).toMatchObject({
+      type: "FRAME",
+      name: "footer#footer",
+      layoutMode: "HORIZONTAL",
+      paddingLeft: 20,
+      paddingRight: 20,
+      paddingTop: 20,
+      paddingBottom: 20,
+      fills: [
+        {
+          type: "SOLID",
+          color: {
+            r: 0.9411764705882353,
+            g: 0.9411764705882353,
+            b: 0.9411764705882353,
+          },
+          opacity: undefined,
+        },
+      ],
+      children: [],
+    });
+  });
+
+  it("空の子要素配列を持つfooter要素を処理できること", () => {
+    const node = {
+      type: "element",
+      tagName: "footer",
+      attributes: {},
+      children: [],
+    };
+
+    const result = FooterElement.mapToFigma(node);
+
+    expect(HTMLToFigmaMapper.mapNode).not.toHaveBeenCalled();
+    expect(result?.children).toEqual([]);
+  });
+
+  it("undefinedの子要素を持つfooter要素を処理できること", () => {
+    const node = {
+      type: "element",
+      tagName: "footer",
+      attributes: {},
+      children: undefined,
+    };
+
+    const result = FooterElement.mapToFigma(node);
+
+    expect(HTMLToFigmaMapper.mapNode).not.toHaveBeenCalled();
+    expect(result?.children).toEqual([]);
+  });
+});

--- a/src/converter/elements/container/footer/footer-element/__tests__/footer-element.toFigmaNode.test.ts
+++ b/src/converter/elements/container/footer/footer-element/__tests__/footer-element.toFigmaNode.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from "vitest";
+import { FooterElement } from "../footer-element";
+import type { FooterElement as FooterElementType } from "../footer-element";
+
+describe("FooterElement.toFigmaNode", () => {
+  it("基本的なfooter要素をFigmaノードに変換できること", () => {
+    const element: FooterElementType = {
+      type: "element",
+      tagName: "footer",
+      attributes: {},
+    };
+
+    const figmaNode = FooterElement.toFigmaNode(element);
+
+    expect(figmaNode.type).toBe("FRAME");
+    expect(figmaNode.name).toBe("footer");
+    expect(figmaNode.layoutMode).toBe("VERTICAL");
+    expect(figmaNode.layoutSizingHorizontal).toBe("FILL");
+  });
+
+  it("ID付きfooter要素の名前が正しく生成されること", () => {
+    const element: FooterElementType = {
+      type: "element",
+      tagName: "footer",
+      attributes: { id: "site-footer" },
+    };
+
+    const figmaNode = FooterElement.toFigmaNode(element);
+
+    expect(figmaNode.name).toBe("footer#site-footer");
+  });
+
+  it("クラス名付きfooter要素の名前が正しく生成されること", () => {
+    const element: FooterElementType = {
+      type: "element",
+      tagName: "footer",
+      attributes: { className: "footer container dark" },
+    };
+
+    const figmaNode = FooterElement.toFigmaNode(element);
+
+    expect(figmaNode.name).toBe("footer.footer");
+  });
+
+  it("IDとクラス名の両方がある場合の名前生成", () => {
+    const element: FooterElementType = {
+      type: "element",
+      tagName: "footer",
+      attributes: { id: "main-footer", className: "site-footer dark" },
+    };
+
+    const figmaNode = FooterElement.toFigmaNode(element);
+
+    expect(figmaNode.name).toBe("footer#main-footer");
+  });
+
+  it("display: flexのスタイルが適用されること", () => {
+    const element: FooterElementType = {
+      type: "element",
+      tagName: "footer",
+      attributes: {
+        style:
+          "display: flex; justify-content: space-between; align-items: center;",
+      },
+    };
+
+    const figmaNode = FooterElement.toFigmaNode(element);
+
+    expect(figmaNode.layoutMode).toBe("HORIZONTAL");
+    expect(figmaNode.primaryAxisAlignItems).toBe("SPACE_BETWEEN");
+    expect(figmaNode.counterAxisAlignItems).toBe("CENTER");
+  });
+
+  it("flex-direction: columnが適用されること", () => {
+    const element: FooterElementType = {
+      type: "element",
+      tagName: "footer",
+      attributes: {
+        style: "display: flex; flex-direction: column;",
+      },
+    };
+
+    const figmaNode = FooterElement.toFigmaNode(element);
+
+    expect(figmaNode.layoutMode).toBe("VERTICAL");
+  });
+
+  it("パディングが正しく適用されること", () => {
+    const element: FooterElementType = {
+      type: "element",
+      tagName: "footer",
+      attributes: {
+        style: "padding: 20px;",
+      },
+    };
+
+    const figmaNode = FooterElement.toFigmaNode(element);
+
+    expect(figmaNode.paddingTop).toBe(20);
+    expect(figmaNode.paddingRight).toBe(20);
+    expect(figmaNode.paddingBottom).toBe(20);
+    expect(figmaNode.paddingLeft).toBe(20);
+  });
+
+  it("個別のパディングが適用されること", () => {
+    const element: FooterElementType = {
+      type: "element",
+      tagName: "footer",
+      attributes: {
+        style: "padding: 10px 20px 30px 40px;",
+      },
+    };
+
+    const figmaNode = FooterElement.toFigmaNode(element);
+
+    expect(figmaNode.paddingTop).toBe(10);
+    expect(figmaNode.paddingRight).toBe(20);
+    expect(figmaNode.paddingBottom).toBe(30);
+    expect(figmaNode.paddingLeft).toBe(40);
+  });
+
+  it("gapが正しく適用されること", () => {
+    const element: FooterElementType = {
+      type: "element",
+      tagName: "footer",
+      attributes: {
+        style: "display: flex; gap: 16px;",
+      },
+    };
+
+    const figmaNode = FooterElement.toFigmaNode(element);
+
+    expect(figmaNode.itemSpacing).toBe(16);
+  });
+
+  it("背景色が正しく適用されること（HEX形式）", () => {
+    const element: FooterElementType = {
+      type: "element",
+      tagName: "footer",
+      attributes: {
+        style: "background-color: #333333;",
+      },
+    };
+
+    const figmaNode = FooterElement.toFigmaNode(element);
+
+    expect(figmaNode.fills).toBeDefined();
+    expect(figmaNode.fills?.[0]).toMatchObject({
+      type: "SOLID",
+      color: { r: 0.2, g: 0.2, b: 0.2 },
+    });
+  });
+
+  it("背景色が正しく適用されること（短縮HEX形式）", () => {
+    const element: FooterElementType = {
+      type: "element",
+      tagName: "footer",
+      attributes: {
+        style: "background-color: #fff;",
+      },
+    };
+
+    const figmaNode = FooterElement.toFigmaNode(element);
+
+    expect(figmaNode.fills).toBeDefined();
+    expect(figmaNode.fills?.[0]).toMatchObject({
+      type: "SOLID",
+      color: { r: 1, g: 1, b: 1 },
+    });
+  });
+
+  it("幅と高さが正しく適用されること", () => {
+    const element: FooterElementType = {
+      type: "element",
+      tagName: "footer",
+      attributes: {
+        style: "width: 800px; height: 100px;",
+      },
+    };
+
+    const figmaNode = FooterElement.toFigmaNode(element);
+
+    expect(figmaNode.width).toBe(800);
+    expect(figmaNode.height).toBe(100);
+  });
+
+  it("最小・最大サイズが適用されること", () => {
+    const element: FooterElementType = {
+      type: "element",
+      tagName: "footer",
+      attributes: {
+        style:
+          "min-width: 320px; max-width: 1200px; min-height: 60px; max-height: 200px;",
+      },
+    };
+
+    const figmaNode = FooterElement.toFigmaNode(element);
+
+    expect(figmaNode).toBeDefined();
+  });
+
+  it("複数のスタイルが組み合わさって適用されること", () => {
+    const element: FooterElementType = {
+      type: "element",
+      tagName: "footer",
+      attributes: {
+        id: "footer",
+        className: "site-footer",
+        style:
+          "display: flex; justify-content: space-between; padding: 20px 30px; background-color: #222; gap: 15px;",
+      },
+    };
+
+    const figmaNode = FooterElement.toFigmaNode(element);
+
+    expect(figmaNode.name).toBe("footer#footer");
+    expect(figmaNode.layoutMode).toBe("HORIZONTAL");
+    expect(figmaNode.primaryAxisAlignItems).toBe("SPACE_BETWEEN");
+    expect(figmaNode.paddingTop).toBeDefined();
+    expect(figmaNode.paddingBottom).toBeDefined();
+    expect(figmaNode.paddingLeft).toBeDefined();
+    expect(figmaNode.paddingRight).toBeDefined();
+    expect(figmaNode.itemSpacing).toBe(15);
+    expect(figmaNode.fills).toBeDefined();
+    expect(figmaNode.fills?.[0]).toMatchObject({
+      type: "SOLID",
+      color: {
+        r: 0.13333333333333333,
+        g: 0.13333333333333333,
+        b: 0.13333333333333333,
+      },
+    });
+  });
+});

--- a/src/converter/elements/container/footer/footer-element/__tests__/footer-element.typeguards.test.ts
+++ b/src/converter/elements/container/footer/footer-element/__tests__/footer-element.typeguards.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { FooterElement } from "../footer-element";
+
+describe("FooterElement.isFooterElement", () => {
+  it("正しいfooter要素を判定できること", () => {
+    const element = {
+      type: "element",
+      tagName: "footer",
+      attributes: {},
+    };
+
+    expect(FooterElement.isFooterElement(element)).toBe(true);
+  });
+
+  it("属性と子要素を持つfooter要素を判定できること", () => {
+    const element = {
+      type: "element",
+      tagName: "footer",
+      attributes: { id: "footer", className: "site-footer" },
+      children: [
+        {
+          type: "element",
+          tagName: "p",
+          attributes: {},
+          children: [{ type: "text", content: "Copyright" }],
+        },
+      ],
+    };
+
+    expect(FooterElement.isFooterElement(element)).toBe(true);
+  });
+
+  it("typeが異なる場合はfalseを返すこと", () => {
+    const element = {
+      type: "text",
+      tagName: "footer",
+      attributes: {},
+    };
+
+    expect(FooterElement.isFooterElement(element)).toBe(false);
+  });
+
+  it("tagNameが異なる場合はfalseを返すこと", () => {
+    const element = {
+      type: "element",
+      tagName: "div",
+      attributes: {},
+    };
+
+    expect(FooterElement.isFooterElement(element)).toBe(false);
+  });
+
+  it("nullの場合はfalseを返すこと", () => {
+    expect(FooterElement.isFooterElement(null)).toBe(false);
+  });
+
+  it("undefinedの場合はfalseを返すこと", () => {
+    expect(FooterElement.isFooterElement(undefined)).toBe(false);
+  });
+
+  it("オブジェクトでない場合はfalseを返すこと", () => {
+    expect(FooterElement.isFooterElement("footer")).toBe(false);
+    expect(FooterElement.isFooterElement(123)).toBe(false);
+    expect(FooterElement.isFooterElement(true)).toBe(false);
+  });
+
+  it("必須プロパティが欠けている場合はfalseを返すこと", () => {
+    expect(FooterElement.isFooterElement({ type: "element" })).toBe(false);
+    expect(FooterElement.isFooterElement({ tagName: "footer" })).toBe(false);
+    expect(FooterElement.isFooterElement({})).toBe(false);
+  });
+});

--- a/src/converter/elements/container/footer/footer-element/footer-element.ts
+++ b/src/converter/elements/container/footer/footer-element/footer-element.ts
@@ -1,0 +1,147 @@
+import type { HTMLNode } from "../../../../models/html-node";
+import type { FooterAttributes } from "../footer-attributes";
+import { FigmaNode, FigmaNodeConfig } from "../../../../models/figma-node";
+import { Styles } from "../../../../models/styles";
+import { HTMLToFigmaMapper } from "../../../../mapper";
+
+/**
+ * footer要素の型定義
+ * HTML5のfooter要素を表現し、Figmaのフレームノードに変換される
+ */
+export interface FooterElement {
+  type: "element";
+  tagName: "footer";
+  attributes: FooterAttributes;
+  children?: HTMLNode[];
+}
+
+/**
+ * footer要素のコンパニオンオブジェクト
+ * 型ガード、ファクトリー、アクセサ、変換メソッドを提供
+ */
+export const FooterElement = {
+  /**
+   * footer要素かどうかを判定する型ガード
+   */
+  isFooterElement(node: unknown): node is FooterElement {
+    return (
+      typeof node === "object" &&
+      node !== null &&
+      "type" in node &&
+      node.type === "element" &&
+      "tagName" in node &&
+      node.tagName === "footer"
+    );
+  },
+
+  /**
+   * footer要素を作成するファクトリー関数
+   */
+  create(
+    attributes: Partial<FooterAttributes> = {},
+    children: HTMLNode[] = [],
+  ): FooterElement {
+    return {
+      type: "element",
+      tagName: "footer",
+      attributes: attributes as FooterAttributes,
+      children,
+    };
+  },
+
+  getId(element: FooterElement): string | undefined {
+    return element.attributes.id;
+  },
+
+  getClassName(element: FooterElement): string | undefined {
+    return element.attributes.className;
+  },
+
+  getStyle(element: FooterElement): string | undefined {
+    return element.attributes.style;
+  },
+
+  getAttribute(element: FooterElement, name: string): unknown {
+    return element.attributes[name as keyof FooterAttributes];
+  },
+
+  getChildren(element: FooterElement): HTMLNode[] | undefined {
+    return element.children;
+  },
+
+  hasAttribute(element: FooterElement, name: string): boolean {
+    return name in element.attributes;
+  },
+
+  /**
+   * footer要素をFigmaノードに変換
+   */
+  toFigmaNode(element: FooterElement): FigmaNodeConfig {
+    let config = FigmaNode.createFrame("footer");
+
+    // applyHtmlElementDefaultsはclassプロパティを期待するため変換が必要
+    const attributesForDefaults = {
+      ...element.attributes,
+      class: element.attributes.className || element.attributes.class,
+    };
+    config = FigmaNodeConfig.applyHtmlElementDefaults(
+      config,
+      "footer",
+      attributesForDefaults,
+    );
+
+    if (!element.attributes?.style) {
+      return config;
+    }
+
+    const styles = Styles.parse(element.attributes.style);
+
+    const backgroundColor = Styles.getBackgroundColor(styles);
+    if (backgroundColor) {
+      config = FigmaNodeConfig.applyBackgroundColor(config, backgroundColor);
+    }
+
+    const padding = Styles.getPadding(styles);
+    if (padding) {
+      config = FigmaNodeConfig.applyPaddingStyles(config, padding);
+    }
+
+    config = FigmaNodeConfig.applyFlexboxStyles(
+      config,
+      Styles.extractFlexboxOptions(styles),
+    );
+
+    config = FigmaNodeConfig.applyBorderStyles(
+      config,
+      Styles.extractBorderOptions(styles),
+    );
+
+    config = FigmaNodeConfig.applySizeStyles(
+      config,
+      Styles.extractSizeOptions(styles),
+    );
+
+    return config;
+  },
+
+  /**
+   * HTMLノードをFigmaノードにマッピング
+   */
+  mapToFigma(node: unknown): FigmaNodeConfig | null {
+    if (!FooterElement.isFooterElement(node)) {
+      return null;
+    }
+
+    const figmaNode = FooterElement.toFigmaNode(node);
+
+    if (node.children && node.children.length > 0) {
+      figmaNode.children = node.children
+        .map((child) => HTMLToFigmaMapper.mapNode(child))
+        .filter((child): child is FigmaNodeConfig => child !== null);
+    } else {
+      figmaNode.children = [];
+    }
+
+    return figmaNode;
+  },
+};

--- a/src/converter/elements/container/footer/footer-element/index.ts
+++ b/src/converter/elements/container/footer/footer-element/index.ts
@@ -1,0 +1,1 @@
+export { FooterElement } from "./footer-element";

--- a/src/converter/elements/container/footer/index.ts
+++ b/src/converter/elements/container/footer/index.ts
@@ -1,0 +1,2 @@
+export { FooterElement } from "./footer-element";
+export type { FooterAttributes } from "./footer-attributes";

--- a/src/converter/elements/container/index.ts
+++ b/src/converter/elements/container/index.ts
@@ -2,3 +2,4 @@ export * from "./div";
 export * from "./section";
 export * from "./article";
 export * from "./main";
+export * from "./footer";


### PR DESCRIPTION
## 📋 概要
HTML5のfooter要素をFigmaのフレームノードに変換する機能を追加しました。

## 🎯 実装内容
- footer要素の型定義とコンバーター実装
- section要素と同様の新しいAPIスタイル（`FigmaNodeConfig.apply*`メソッド）を採用
- TDDアプローチによる包括的なテスト実装

## ✅ 変更点
### 新規ファイル
- `footer-element/footer-element.ts`: メインのコンバーター実装（147行）
- `footer-attributes/footer-attributes.ts`: footer要素の属性定義
- 6個のテストファイル（factory, typeguards, accessors, toFigmaNode, mapToFigma, attributes）

### 修正ファイル
- `container/index.ts`: footer要素のエクスポート追加

## 📊 テスト結果
- ✅ 全56個のテストケース合格
- ✅ TypeScriptコンパイル成功
- ✅ ESLint警告・エラーなし

## 🔄 関連Issue
フェーズ2: コンテナ要素の実装（plan.md参照）

## 🚀 実装詳細

### コンパニオンオブジェクトパターン
```typescript
export const FooterElement = {
  isFooterElement(node: unknown): node is FooterElement
  create(attributes?, children?): FooterElement
  toFigmaNode(element: FooterElement): FigmaNodeConfig
  mapToFigma(node: unknown): FigmaNodeConfig | null
}
```

### 新APIスタイルの採用
section要素と同様の実装パターンを採用し、コードの一貫性を保持：
- `FigmaNodeConfig.applyHtmlElementDefaults`
- `FigmaNodeConfig.applyBackgroundColor`
- `FigmaNodeConfig.applyPaddingStyles`
- `FigmaNodeConfig.applyFlexboxStyles`
- `FigmaNodeConfig.applyBorderStyles`
- `FigmaNodeConfig.applySizeStyles`

### コメント改善
コメントレビューエージェントによる指摘に基づき、「何を」から「なぜ」にフォーカスしたコメントに改善しました。

🤖 Generated with [Claude Code](https://claude.ai/code)