### PR TITLE
✨ [New Feature]: HTML5 aside要素をFigmaノードに変換する機能を実装

### DIFF
--- a/src/converter/elements/container/aside/aside-attributes/__tests__/aside-attributes.test.ts
+++ b/src/converter/elements/container/aside/aside-attributes/__tests__/aside-attributes.test.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "vitest";
+import type { AsideAttributes } from "../aside-attributes";
+
+test("AsideAttributes: グローバル属性を含むこと", () => {
+  const attributes: AsideAttributes = {
+    id: "sidebar",
+    className: "sidebar-content",
+    style: "width: 300px;",
+  };
+
+  expect(attributes.id).toBe("sidebar");
+  expect(attributes.className).toBe("sidebar-content");
+  expect(attributes.style).toBe("width: 300px;");
+});
+
+test("AsideAttributes: role属性を設定できること", () => {
+  const attributes: AsideAttributes = {
+    role: "complementary",
+  };
+
+  expect(attributes.role).toBe("complementary");
+});
+
+test("AsideAttributes: aria-label属性を設定できること", () => {
+  const attributes: AsideAttributes = {
+    "aria-label": "サイドバー",
+  };
+
+  expect(attributes["aria-label"]).toBe("サイドバー");
+});
+
+test("AsideAttributes: 空の属性オブジェクトを作成できること", () => {
+  const attributes: AsideAttributes = {};
+
+  expect(attributes).toEqual({});
+});
+
+test("AsideAttributes: 複数の属性を組み合わせて使用できること", () => {
+  const attributes: AsideAttributes = {
+    id: "sidebar",
+    className: "sidebar navigation",
+    style: "background-color: #f0f0f0;",
+    role: "complementary",
+    "aria-label": "メインサイドバー",
+  };
+
+  expect(attributes.id).toBe("sidebar");
+  expect(attributes.className).toBe("sidebar navigation");
+  expect(attributes.style).toBe("background-color: #f0f0f0;");
+  expect(attributes.role).toBe("complementary");
+  expect(attributes["aria-label"]).toBe("メインサイドバー");
+});

--- a/src/converter/elements/container/aside/aside-attributes/aside-attributes.ts
+++ b/src/converter/elements/container/aside/aside-attributes/aside-attributes.ts
@@ -1,0 +1,6 @@
+import type { GlobalAttributes } from "../../../base/global-attributes";
+
+// aside要素の属性定義
+// 現時点ではGlobalAttributesのみを継承
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface AsideAttributes extends GlobalAttributes {}

--- a/src/converter/elements/container/aside/aside-attributes/index.ts
+++ b/src/converter/elements/container/aside/aside-attributes/index.ts
@@ -1,0 +1,1 @@
+export type { AsideAttributes } from "./aside-attributes";

--- a/src/converter/elements/container/aside/aside-element/__tests__/aside-element.accessors.test.ts
+++ b/src/converter/elements/container/aside/aside-element/__tests__/aside-element.accessors.test.ts
@@ -1,0 +1,124 @@
+import { test, expect } from "vitest";
+import { AsideElement } from "../aside-element";
+
+// getId
+test("AsideElement.getId: ID属性を取得できること", () => {
+  const element = AsideElement.create({ id: "sidebar" });
+  expect(AsideElement.getId(element)).toBe("sidebar");
+});
+
+test("AsideElement.getId: ID属性がない場合はundefinedを返すこと", () => {
+  const element = AsideElement.create({});
+  expect(AsideElement.getId(element)).toBeUndefined();
+});
+
+// getClassName
+test("AsideElement.getClassName: className属性を取得できること", () => {
+  const element = AsideElement.create({ className: "sidebar navigation" });
+  expect(AsideElement.getClassName(element)).toBe("sidebar navigation");
+});
+
+test("AsideElement.getClassName: className属性がない場合はundefinedを返すこと", () => {
+  const element = AsideElement.create({});
+  expect(AsideElement.getClassName(element)).toBeUndefined();
+});
+
+// getStyle
+test("AsideElement.getStyle: style属性を取得できること", () => {
+  const element = AsideElement.create({ style: "width: 300px;" });
+  expect(AsideElement.getStyle(element)).toBe("width: 300px;");
+});
+
+test("AsideElement.getStyle: style属性がない場合はundefinedを返すこと", () => {
+  const element = AsideElement.create({});
+  expect(AsideElement.getStyle(element)).toBeUndefined();
+});
+
+// getAttribute
+test("AsideElement.getAttribute: 指定した属性を取得できること", () => {
+  const element = AsideElement.create({
+    id: "sidebar",
+    className: "navigation",
+    role: "complementary",
+  });
+
+  expect(AsideElement.getAttribute(element, "id")).toBe("sidebar");
+  expect(AsideElement.getAttribute(element, "className")).toBe("navigation");
+  expect(AsideElement.getAttribute(element, "role")).toBe("complementary");
+});
+
+test("AsideElement.getAttribute: 存在しない属性の場合はundefinedを返すこと", () => {
+  const element = AsideElement.create({ id: "sidebar" });
+  expect(AsideElement.getAttribute(element, "className")).toBeUndefined();
+});
+
+test("AsideElement.getAttribute: ARIA属性を取得できること", () => {
+  const element = AsideElement.create({
+    "aria-label": "サイドバー",
+  });
+  expect(AsideElement.getAttribute(element, "aria-label")).toBe("サイドバー");
+});
+
+// getChildren
+test("AsideElement.getChildren: 子要素を取得できること", () => {
+  const children = [
+    {
+      type: "text" as const,
+      content: "Sidebar content",
+    },
+  ];
+  const element = AsideElement.create({}, children);
+
+  expect(AsideElement.getChildren(element)).toEqual(children);
+});
+
+test("AsideElement.getChildren: 子要素がない場合は空配列を返すこと", () => {
+  const element = AsideElement.create({}, []);
+  expect(AsideElement.getChildren(element)).toEqual([]);
+});
+
+test("AsideElement.getChildren: 子要素が未定義の場合はundefinedを返すこと", () => {
+  const element = {
+    type: "element" as const,
+    tagName: "aside" as const,
+    attributes: {},
+  };
+  expect(AsideElement.getChildren(element)).toBeUndefined();
+});
+
+// hasAttribute
+test("AsideElement.hasAttribute: 属性が存在する場合はtrueを返すこと", () => {
+  const element = AsideElement.create({
+    id: "sidebar",
+    className: "navigation",
+  });
+
+  expect(AsideElement.hasAttribute(element, "id")).toBe(true);
+  expect(AsideElement.hasAttribute(element, "className")).toBe(true);
+});
+
+test("AsideElement.hasAttribute: 属性が存在しない場合はfalseを返すこと", () => {
+  const element = AsideElement.create({ id: "sidebar" });
+
+  expect(AsideElement.hasAttribute(element, "className")).toBe(false);
+  expect(AsideElement.hasAttribute(element, "style")).toBe(false);
+});
+
+test("AsideElement.hasAttribute: 値がundefinedでも属性が存在すればtrueを返すこと", () => {
+  const element = AsideElement.create({
+    id: undefined,
+  });
+
+  expect(AsideElement.hasAttribute(element, "id")).toBe(true);
+});
+
+test("AsideElement.hasAttribute: ARIA属性の存在を確認できること", () => {
+  const element = AsideElement.create({
+    "aria-label": "サイドバー",
+    role: "complementary",
+  });
+
+  expect(AsideElement.hasAttribute(element, "aria-label")).toBe(true);
+  expect(AsideElement.hasAttribute(element, "role")).toBe(true);
+  expect(AsideElement.hasAttribute(element, "aria-hidden")).toBe(false);
+});

--- a/src/converter/elements/container/aside/aside-element/__tests__/aside-element.factory.test.ts
+++ b/src/converter/elements/container/aside/aside-element/__tests__/aside-element.factory.test.ts
@@ -1,0 +1,101 @@
+import { test, expect } from "vitest";
+import { AsideElement } from "../aside-element";
+
+test("AsideElement.create: 属性なしでaside要素を作成できること", () => {
+  const element = AsideElement.create();
+
+  expect(element).toEqual({
+    type: "element",
+    tagName: "aside",
+    attributes: {},
+    children: [],
+  });
+});
+
+test("AsideElement.create: 属性を指定してaside要素を作成できること", () => {
+  const attributes = {
+    id: "sidebar",
+    className: "navigation",
+    style: "width: 300px;",
+  };
+
+  const element = AsideElement.create(attributes);
+
+  expect(element.attributes).toEqual(attributes);
+  expect(element.type).toBe("element");
+  expect(element.tagName).toBe("aside");
+  expect(element.children).toEqual([]);
+});
+
+test("AsideElement.create: 子要素を指定してaside要素を作成できること", () => {
+  const children = [
+    {
+      type: "text" as const,
+      content: "Sidebar content",
+    },
+  ];
+
+  const element = AsideElement.create({}, children);
+
+  expect(element.children).toEqual(children);
+  expect(element.type).toBe("element");
+  expect(element.tagName).toBe("aside");
+});
+
+test("AsideElement.create: 属性と子要素を指定してaside要素を作成できること", () => {
+  const attributes = {
+    id: "sidebar",
+    role: "complementary",
+  };
+  const children = [
+    {
+      type: "element" as const,
+      tagName: "h3",
+      attributes: {},
+      children: [
+        {
+          type: "text" as const,
+          content: "関連情報",
+        },
+      ],
+    },
+  ];
+
+  const element = AsideElement.create(attributes, children);
+
+  expect(element.attributes).toEqual(attributes);
+  expect(element.children).toEqual(children);
+  expect(element.type).toBe("element");
+  expect(element.tagName).toBe("aside");
+});
+
+test("AsideElement.create: 空の属性と空の子要素でaside要素を作成できること", () => {
+  const element = AsideElement.create({}, []);
+
+  expect(element).toEqual({
+    type: "element",
+    tagName: "aside",
+    attributes: {},
+    children: [],
+  });
+});
+
+test("AsideElement.create: 部分的な属性でaside要素を作成できること", () => {
+  const element = AsideElement.create({ id: "sidebar" });
+
+  expect(element.attributes.id).toBe("sidebar");
+  expect(element.type).toBe("element");
+  expect(element.tagName).toBe("aside");
+});
+
+test("AsideElement.create: ARIA属性を含むaside要素を作成できること", () => {
+  const attributes = {
+    "aria-label": "サイドバー",
+    role: "complementary",
+  };
+
+  const element = AsideElement.create(attributes);
+
+  expect(element.attributes["aria-label"]).toBe("サイドバー");
+  expect(element.attributes.role).toBe("complementary");
+});

--- a/src/converter/elements/container/aside/aside-element/__tests__/aside-element.mapToFigma.test.ts
+++ b/src/converter/elements/container/aside/aside-element/__tests__/aside-element.mapToFigma.test.ts
@@ -1,0 +1,152 @@
+import { test, expect, vi, beforeEach } from "vitest";
+import { AsideElement } from "../aside-element";
+import type { AsideElement as AsideElementType } from "../aside-element";
+
+// テスト用のHTMLNode型定義
+type TestTextNode = { type: "text"; content: string };
+type TestCommentNode = { type: "comment"; content: string };
+
+// HTMLToFigmaMapperのモック
+vi.mock("../../../../../mapper", () => ({
+  HTMLToFigmaMapper: {
+    mapNode: vi.fn(),
+  },
+}));
+
+import { HTMLToFigmaMapper } from "../../../../../mapper";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("AsideElement.mapToFigma: aside要素でない場合はnullを返すこと", () => {
+  const node = {
+    type: "element",
+    tagName: "div",
+    attributes: {},
+  };
+
+  const result = AsideElement.mapToFigma(node);
+  expect(result).toBeNull();
+});
+
+test("AsideElement.mapToFigma: aside要素をFigmaノードに変換できること", () => {
+  const element: AsideElementType = {
+    type: "element",
+    tagName: "aside",
+    attributes: {
+      id: "sidebar",
+    },
+  };
+
+  const result = AsideElement.mapToFigma(element);
+
+  expect(result).not.toBeNull();
+  expect(result?.type).toBe("FRAME");
+  expect(result?.name).toBe("aside#sidebar");
+  expect(result?.children).toEqual([]);
+});
+
+test("AsideElement.mapToFigma: 子要素を持つaside要素を変換できること", () => {
+  const childFigmaNode = {
+    type: "TEXT" as const,
+    name: "text",
+    content: "子要素",
+  };
+
+  vi.mocked(HTMLToFigmaMapper.mapNode).mockReturnValue(childFigmaNode);
+
+  const element: AsideElementType = {
+    type: "element",
+    tagName: "aside",
+    attributes: {},
+    children: [
+      {
+        type: "text",
+        content: "子要素",
+      } as TestTextNode,
+    ],
+  };
+
+  const result = AsideElement.mapToFigma(element);
+
+  expect(result?.children).toEqual([childFigmaNode]);
+  expect(HTMLToFigmaMapper.mapNode).toHaveBeenCalledWith({
+    type: "text",
+    content: "子要素",
+  });
+});
+
+test("AsideElement.mapToFigma: 複数の子要素を持つaside要素を変換できること", () => {
+  const child1 = { type: "TEXT" as const, name: "text1", content: "子要素1" };
+  const child2 = { type: "TEXT" as const, name: "text2", content: "子要素2" };
+
+  vi.mocked(HTMLToFigmaMapper.mapNode)
+    .mockReturnValueOnce(child1)
+    .mockReturnValueOnce(child2);
+
+  const element: AsideElementType = {
+    type: "element",
+    tagName: "aside",
+    attributes: {},
+    children: [
+      { type: "text", content: "子要素1" } as TestTextNode,
+      { type: "text", content: "子要素2" } as TestTextNode,
+    ],
+  };
+
+  const result = AsideElement.mapToFigma(element);
+
+  expect(result?.children).toEqual([child1, child2]);
+  expect(HTMLToFigmaMapper.mapNode).toHaveBeenCalledTimes(2);
+});
+
+test("AsideElement.mapToFigma: nullを返す子要素はフィルタリングされること", () => {
+  const childFigmaNode = {
+    type: "TEXT" as const,
+    name: "text",
+    content: "有効な子要素",
+  };
+
+  vi.mocked(HTMLToFigmaMapper.mapNode)
+    .mockReturnValueOnce(null!)
+    .mockReturnValueOnce(childFigmaNode)
+    .mockReturnValueOnce(null!);
+
+  const element: AsideElementType = {
+    type: "element",
+    tagName: "aside",
+    attributes: {},
+    children: [
+      { type: "comment", content: "コメント" } as TestCommentNode,
+      { type: "text", content: "有効な子要素" } as TestTextNode,
+      { type: "comment", content: "別のコメント" } as TestCommentNode,
+    ],
+  };
+
+  const result = AsideElement.mapToFigma(element);
+
+  expect(result?.children).toEqual([childFigmaNode]);
+  expect(HTMLToFigmaMapper.mapNode).toHaveBeenCalledTimes(3);
+});
+
+test("AsideElement.mapToFigma: スタイル付きaside要素を変換できること", () => {
+  const element: AsideElementType = {
+    type: "element",
+    tagName: "aside",
+    attributes: {
+      id: "sidebar",
+      className: "navigation",
+      style: "width: 300px; padding: 20px;",
+    },
+  };
+
+  const result = AsideElement.mapToFigma(element);
+
+  expect(result?.name).toBe("aside#sidebar.navigation");
+  expect(result?.width).toBe(300);
+  expect(result?.paddingTop).toBe(20);
+  expect(result?.paddingRight).toBe(20);
+  expect(result?.paddingBottom).toBe(20);
+  expect(result?.paddingLeft).toBe(20);
+});

--- a/src/converter/elements/container/aside/aside-element/__tests__/aside-element.toFigmaNode.test.ts
+++ b/src/converter/elements/container/aside/aside-element/__tests__/aside-element.toFigmaNode.test.ts
@@ -1,0 +1,144 @@
+import { test, expect } from "vitest";
+import { AsideElement } from "../aside-element";
+import type { AsideElement as AsideElementType } from "../aside-element";
+
+test("AsideElement.toFigmaNode: 基本的なaside要素をFigmaノードに変換できること", () => {
+  const element: AsideElementType = {
+    type: "element",
+    tagName: "aside",
+    attributes: {},
+  };
+
+  const result = AsideElement.toFigmaNode(element);
+
+  expect(result.type).toBe("FRAME");
+  expect(result.name).toBe("aside");
+  expect(result.layoutMode).toBe("VERTICAL");
+  expect(result.layoutSizingVertical).toBe("HUG");
+  expect(result.layoutSizingHorizontal).toBe("FIXED");
+});
+
+test("AsideElement.toFigmaNode: ID属性がある場合は名前に含めること", () => {
+  const element = AsideElement.create({ id: "sidebar" });
+  const result = AsideElement.toFigmaNode(element);
+
+  expect(result.name).toBe("aside#sidebar");
+});
+
+test("AsideElement.toFigmaNode: className属性がある場合は名前に含めること", () => {
+  const element = AsideElement.create({ className: "sidebar navigation" });
+  const result = AsideElement.toFigmaNode(element);
+
+  expect(result.name).toBe("aside.sidebar.navigation");
+});
+
+test("AsideElement.toFigmaNode: IDとclassName両方がある場合は両方を名前に含めること", () => {
+  const element = AsideElement.create({
+    id: "sidebar",
+    className: "navigation",
+  });
+  const result = AsideElement.toFigmaNode(element);
+
+  expect(result.name).toBe("aside#sidebar.navigation");
+});
+
+test("AsideElement.toFigmaNode: role属性がある場合は名前に含めること", () => {
+  const element = AsideElement.create({ role: "complementary" });
+  const result = AsideElement.toFigmaNode(element);
+
+  expect(result.name).toBe("aside[role=complementary]");
+});
+
+test("AsideElement.toFigmaNode: aria-label属性がある場合は名前に含めること", () => {
+  const element = AsideElement.create({ "aria-label": "サイドバー" });
+  const result = AsideElement.toFigmaNode(element);
+
+  expect(result.name).toBe("aside[aria-label=サイドバー]");
+});
+
+test("AsideElement.toFigmaNode: Flexboxスタイルを適用できること", () => {
+  const element = AsideElement.create({
+    style:
+      "display: flex; flex-direction: row; justify-content: center; align-items: flex-end;",
+  });
+  const result = AsideElement.toFigmaNode(element);
+
+  expect(result.layoutMode).toBe("HORIZONTAL");
+  expect(result.primaryAxisAlignItems).toBe("CENTER");
+  expect(result.counterAxisAlignItems).toBe("MAX");
+});
+
+test("AsideElement.toFigmaNode: パディングスタイルを適用できること", () => {
+  const element = AsideElement.create({
+    style: "padding: 20px;",
+  });
+  const result = AsideElement.toFigmaNode(element);
+
+  expect(result.paddingTop).toBe(20);
+  expect(result.paddingRight).toBe(20);
+  expect(result.paddingBottom).toBe(20);
+  expect(result.paddingLeft).toBe(20);
+});
+
+test("AsideElement.toFigmaNode: 個別パディングスタイルを適用できること", () => {
+  const element = AsideElement.create({
+    style:
+      "padding-top: 10px; padding-right: 20px; padding-bottom: 30px; padding-left: 40px;",
+  });
+  const result = AsideElement.toFigmaNode(element);
+
+  expect(result.paddingTop).toBe(10);
+  expect(result.paddingRight).toBe(20);
+  expect(result.paddingBottom).toBe(30);
+  expect(result.paddingLeft).toBe(40);
+});
+
+test("AsideElement.toFigmaNode: ギャップスタイルを適用できること", () => {
+  const element = AsideElement.create({
+    style: "gap: 16px;",
+  });
+  const result = AsideElement.toFigmaNode(element);
+
+  expect(result.itemSpacing).toBe(16);
+});
+
+test("AsideElement.toFigmaNode: 背景色スタイルを適用できること", () => {
+  const element = AsideElement.create({
+    style: "background-color: #ff0000;",
+  });
+  const result = AsideElement.toFigmaNode(element);
+
+  expect(result.fills).toEqual([
+    {
+      type: "SOLID",
+      color: { r: 1, g: 0, b: 0 },
+      opacity: undefined,
+      visible: true,
+    },
+  ]);
+});
+
+test("AsideElement.toFigmaNode: サイズスタイルを適用できること", () => {
+  const element = AsideElement.create({
+    style: "width: 300px; height: 500px;",
+  });
+  const result = AsideElement.toFigmaNode(element);
+
+  expect(result.width).toBe(300);
+  expect(result.height).toBe(500);
+  expect(result.layoutSizingHorizontal).toBe("FIXED");
+  expect(result.layoutSizingVertical).toBe("FIXED");
+});
+
+test("AsideElement.toFigmaNode: 最小・最大サイズスタイルを適用できること", () => {
+  const element = AsideElement.create({
+    style:
+      "min-width: 200px; max-width: 400px; min-height: 100px; max-height: 600px;",
+  });
+  const result = AsideElement.toFigmaNode(element);
+
+  expect(result.minWidth).toBe(200);
+  expect(result.maxWidth).toBe(400);
+  expect(result.minHeight).toBe(100);
+  expect(result.maxHeight).toBe(600);
+});

--- a/src/converter/elements/container/aside/aside-element/__tests__/aside-element.typeguards.test.ts
+++ b/src/converter/elements/container/aside/aside-element/__tests__/aside-element.typeguards.test.ts
@@ -1,0 +1,95 @@
+import { test, expect } from "vitest";
+import { AsideElement } from "../aside-element";
+
+test("AsideElement.isAsideElement: aside要素の場合はtrueを返すこと", () => {
+  const element = {
+    type: "element",
+    tagName: "aside",
+    attributes: {},
+  };
+
+  expect(AsideElement.isAsideElement(element)).toBe(true);
+});
+
+test("AsideElement.isAsideElement: タグ名が異なる場合はfalseを返すこと", () => {
+  const element = {
+    type: "element",
+    tagName: "div",
+    attributes: {},
+  };
+
+  expect(AsideElement.isAsideElement(element)).toBe(false);
+});
+
+test("AsideElement.isAsideElement: typeがelementでない場合はfalseを返すこと", () => {
+  const element = {
+    type: "text",
+    content: "text",
+  };
+
+  expect(AsideElement.isAsideElement(element)).toBe(false);
+});
+
+test("AsideElement.isAsideElement: nullの場合はfalseを返すこと", () => {
+  expect(AsideElement.isAsideElement(null)).toBe(false);
+});
+
+test("AsideElement.isAsideElement: undefinedの場合はfalseを返すこと", () => {
+  expect(AsideElement.isAsideElement(undefined)).toBe(false);
+});
+
+test("AsideElement.isAsideElement: 文字列の場合はfalseを返すこと", () => {
+  expect(AsideElement.isAsideElement("aside")).toBe(false);
+});
+
+test("AsideElement.isAsideElement: 数値の場合はfalseを返すこと", () => {
+  expect(AsideElement.isAsideElement(123)).toBe(false);
+});
+
+test("AsideElement.isAsideElement: オブジェクトだがtypeプロパティがない場合はfalseを返すこと", () => {
+  const element = {
+    tagName: "aside",
+    attributes: {},
+  };
+
+  expect(AsideElement.isAsideElement(element)).toBe(false);
+});
+
+test("AsideElement.isAsideElement: オブジェクトだがtagNameプロパティがない場合はfalseを返すこと", () => {
+  const element = {
+    type: "element",
+    attributes: {},
+  };
+
+  expect(AsideElement.isAsideElement(element)).toBe(false);
+});
+
+test("AsideElement.isAsideElement: 子要素を持つaside要素の場合もtrueを返すこと", () => {
+  const element = {
+    type: "element",
+    tagName: "aside",
+    attributes: {},
+    children: [
+      {
+        type: "text",
+        content: "Sidebar content",
+      },
+    ],
+  };
+
+  expect(AsideElement.isAsideElement(element)).toBe(true);
+});
+
+test("AsideElement.isAsideElement: 属性を持つaside要素の場合もtrueを返すこと", () => {
+  const element = {
+    type: "element",
+    tagName: "aside",
+    attributes: {
+      id: "sidebar",
+      className: "navigation",
+      role: "complementary",
+    },
+  };
+
+  expect(AsideElement.isAsideElement(element)).toBe(true);
+});

--- a/src/converter/elements/container/aside/aside-element/aside-element.ts
+++ b/src/converter/elements/container/aside/aside-element/aside-element.ts
@@ -1,0 +1,239 @@
+import type { HTMLNode } from "../../../../models/html-node";
+import { FigmaNodeConfig, FigmaNode } from "../../../../models/figma-node";
+import type { AsideAttributes } from "../aside-attributes";
+import { Styles } from "../../../../models/styles";
+import { HTMLToFigmaMapper } from "../../../../mapper";
+
+/**
+ * aside要素の型定義
+ * HTML5のaside要素を表現し、Figmaのフレームノードに変換される
+ */
+export interface AsideElement {
+  type: "element";
+  tagName: "aside";
+  attributes: AsideAttributes;
+  children?: HTMLNode[];
+}
+
+/**
+ * aside要素のコンパニオンオブジェクト
+ * 型ガード、ファクトリー、アクセサ、変換メソッドを提供
+ */
+export const AsideElement = {
+  /**
+   * aside要素かどうかを判定する型ガード
+   */
+  isAsideElement(node: unknown): node is AsideElement {
+    return (
+      typeof node === "object" &&
+      node !== null &&
+      "type" in node &&
+      node.type === "element" &&
+      "tagName" in node &&
+      node.tagName === "aside"
+    );
+  },
+
+  /**
+   * aside要素を作成するファクトリー関数
+   */
+  create(
+    attributes: Partial<AsideAttributes> = {},
+    children: HTMLNode[] = [],
+  ): AsideElement {
+    return {
+      type: "element",
+      tagName: "aside",
+      attributes: attributes as AsideAttributes,
+      children,
+    };
+  },
+
+  /**
+   * ID属性を取得
+   */
+  getId(element: AsideElement): string | undefined {
+    return element.attributes.id;
+  },
+
+  /**
+   * className属性を取得
+   */
+  getClassName(element: AsideElement): string | undefined {
+    return element.attributes.className;
+  },
+
+  /**
+   * style属性を取得
+   */
+  getStyle(element: AsideElement): string | undefined {
+    return element.attributes.style;
+  },
+
+  /**
+   * 任意の属性を取得
+   */
+  getAttribute(element: AsideElement, name: string): unknown {
+    return element.attributes[name as keyof AsideAttributes];
+  },
+
+  /**
+   * 子要素を取得
+   */
+  getChildren(element: AsideElement): HTMLNode[] | undefined {
+    return element.children;
+  },
+
+  /**
+   * 属性の存在確認
+   */
+  hasAttribute(element: AsideElement, name: string): boolean {
+    return name in element.attributes;
+  },
+
+  /**
+   * aside要素をFigmaノードに変換
+   */
+  toFigmaNode(element: AsideElement): FigmaNodeConfig {
+    let config = FigmaNode.createFrame("aside");
+
+    // ノード名の生成
+    let name = "aside";
+    if (element.attributes.id) {
+      name += `#${element.attributes.id}`;
+    }
+    if (element.attributes.className) {
+      const classes = element.attributes.className.split(" ").filter(Boolean);
+      if (classes.length > 0) {
+        name += `.${classes.join(".")}`;
+      }
+    }
+    if (element.attributes.role) {
+      name += `[role=${element.attributes.role}]`;
+    }
+    if (element.attributes["aria-label"]) {
+      name += `[aria-label=${element.attributes["aria-label"]}]`;
+    }
+    config.name = name;
+
+    // asideのデフォルトレイアウト設定
+    config.layoutMode = "VERTICAL";
+    config.layoutSizingHorizontal = "FIXED";
+    config.layoutSizingVertical = "HUG";
+
+    // スタイルがない場合は早期リターン
+    if (!element.attributes?.style) {
+      return config;
+    }
+
+    const styles = Styles.parse(element.attributes.style);
+
+    // 背景色を適用
+    const backgroundColor = Styles.getBackgroundColor(styles);
+    if (backgroundColor) {
+      config = FigmaNodeConfig.applyBackgroundColor(config, backgroundColor);
+    }
+
+    // パディングを適用
+    const padding = Styles.getPadding(styles);
+    if (padding) {
+      config = FigmaNodeConfig.applyPaddingStyles(config, padding);
+    }
+
+    // 個別パディングも処理
+    const paddingTop = Styles.getPaddingTop(styles);
+    const paddingRight = Styles.getPaddingRight(styles);
+    const paddingBottom = Styles.getPaddingBottom(styles);
+    const paddingLeft = Styles.getPaddingLeft(styles);
+
+    if (paddingTop !== null && typeof paddingTop === "number") {
+      config.paddingTop = paddingTop;
+    }
+    if (paddingRight !== null && typeof paddingRight === "number") {
+      config.paddingRight = paddingRight;
+    }
+    if (paddingBottom !== null && typeof paddingBottom === "number") {
+      config.paddingBottom = paddingBottom;
+    }
+    if (paddingLeft !== null && typeof paddingLeft === "number") {
+      config.paddingLeft = paddingLeft;
+    }
+
+    // Flexboxスタイルを適用（常に実行、内部で判定）
+    const flexboxOptions = Styles.extractFlexboxOptions(styles);
+    config = FigmaNodeConfig.applyFlexboxStyles(config, flexboxOptions);
+
+    // gapをitemSpacingとして適用
+    if (flexboxOptions.gap !== undefined) {
+      config.itemSpacing = flexboxOptions.gap;
+    }
+
+    // ボーダースタイルを適用（常に実行、内部で判定）
+    config = FigmaNodeConfig.applyBorderStyles(
+      config,
+      Styles.extractBorderOptions(styles),
+    );
+
+    // サイズスタイルを適用（常に実行、内部で判定）
+    const sizeOptions = Styles.extractSizeOptions(styles);
+    config = FigmaNodeConfig.applySizeStyles(config, sizeOptions);
+
+    // width/heightが明示的に設定されている場合はlayoutSizingを調整
+    if (sizeOptions.width !== undefined) {
+      config.layoutSizingHorizontal = "FIXED";
+    }
+    if (sizeOptions.height !== undefined) {
+      config.layoutSizingVertical = "FIXED";
+    }
+
+    // 最小・最大サイズの処理
+    if (styles["min-width"]) {
+      const minWidth = parseFloat(styles["min-width"]);
+      if (!isNaN(minWidth)) {
+        config.minWidth = minWidth;
+      }
+    }
+    if (styles["max-width"]) {
+      const maxWidth = parseFloat(styles["max-width"]);
+      if (!isNaN(maxWidth)) {
+        config.maxWidth = maxWidth;
+      }
+    }
+    if (styles["min-height"]) {
+      const minHeight = parseFloat(styles["min-height"]);
+      if (!isNaN(minHeight)) {
+        config.minHeight = minHeight;
+      }
+    }
+    if (styles["max-height"]) {
+      const maxHeight = parseFloat(styles["max-height"]);
+      if (!isNaN(maxHeight)) {
+        config.maxHeight = maxHeight;
+      }
+    }
+
+    return config;
+  },
+
+  /**
+   * HTMLノードをFigmaノードにマッピング
+   */
+  mapToFigma(node: unknown): FigmaNodeConfig | null {
+    if (!AsideElement.isAsideElement(node)) {
+      return null;
+    }
+
+    const figmaNode = AsideElement.toFigmaNode(node);
+
+    // 子要素の処理
+    if (node.children && node.children.length > 0) {
+      figmaNode.children = node.children
+        .map((child) => HTMLToFigmaMapper.mapNode(child))
+        .filter((child): child is FigmaNodeConfig => child !== null);
+    } else {
+      figmaNode.children = [];
+    }
+
+    return figmaNode;
+  },
+};

--- a/src/converter/elements/container/aside/aside-element/index.ts
+++ b/src/converter/elements/container/aside/aside-element/index.ts
@@ -1,0 +1,1 @@
+export { AsideElement } from "./aside-element";

--- a/src/converter/elements/container/aside/index.ts
+++ b/src/converter/elements/container/aside/index.ts
@@ -1,0 +1,2 @@
+export { AsideElement } from "./aside-element";
+export type { AsideAttributes } from "./aside-attributes";


### PR DESCRIPTION
$(cat <<'EOF'
## 概要
HTML5の`<aside>`要素をFigmaのフレームノードに変換する機能を実装しました。

## 変更内容
- ✨ AsideAttributes インターフェースの定義
- ✨ AsideElement 型定義とコンパニオンオブジェクトの実装
- ✨ toFigmaNodeメソッドによる各種スタイル対応:
  - 背景色の適用
  - パディングの適用（全体および個別）
  - Flexboxレイアウト対応
  - ボーダースタイル対応
  - サイズ設定（width/height）と自動layoutSizing調整
  - 最小・最大サイズの処理
- ✅ 包括的なテストカバレッジ（全58テスト）

## 実装詳細
### ファイル構造
```
src/converter/elements/container/aside/
├── aside-attributes/
│   ├── __tests__/
│   │   └── aside-attributes.test.ts
│   ├── aside-attributes.ts
│   └── index.ts
├── aside-element/
│   ├── __tests__/
│   │   ├── aside-element.accessors.test.ts
│   │   ├── aside-element.factory.test.ts
│   │   ├── aside-element.mapToFigma.test.ts
│   │   ├── aside-element.toFigmaNode.test.ts
│   │   └── aside-element.typeguards.test.ts
│   ├── aside-element.ts
│   └── index.ts
└── index.ts
```

### 特徴
- TDD（テスト駆動開発）アプローチによる実装
- div要素と同様のパターンでFigmaNodeConfigヘルパーメソッドを活用
- Kent C. Dodds推奨のフラットなテスト構造
- 型安全性を保証するTypeScript実装

## テスト結果
```
Test Files  6 passed (6)
Tests      58 passed (58)
```

## チェックリスト
- [x] テストの実行と成功確認
- [x] Lintチェック通過
- [x] TypeScript型チェック通過
- [x] 既存パターンとの整合性確認
- [x] コードレビュー準備完了

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)