### PR TITLE
♻️ buildNodeName関数の汎用化とHTMLNode機能の改善

### DIFF
--- a/src/converter/elements/base/base-element/base-element.ts
+++ b/src/converter/elements/base/base-element/base-element.ts
@@ -1,20 +1,27 @@
 /**
  * HTML要素の基底インターフェース
  * 全てのHTML要素型はこのインターフェースを拡張する
- * 
+ *
  * @template T - HTML要素のタグ名
+ * @template A - 属性の型（デフォルトはRecord<string, unknown>）
  */
-export interface BaseElement<T extends string> {
+export interface BaseElement<T extends string, A = Record<string, unknown>> {
   /**
    * ノードタイプ（常に'element'）
    */
-  type: 'element';
-  
+  type: "element";
+
   /**
    * HTML要素のタグ名
    */
   tagName: T;
-  
+
+  /**
+   * 要素の属性
+   * 各要素は独自の属性型を定義可能
+   */
+  attributes?: A;
+
   /**
    * 子要素の配列
    * 要素によっては子要素を持たない場合があるため、optional

--- a/src/converter/elements/container/div/div-element/div-element.ts
+++ b/src/converter/elements/container/div/div-element/div-element.ts
@@ -1,13 +1,13 @@
-import { FigmaNodeConfig, FigmaNode } from '../../../../models/figma-node';
-import { Styles } from '../../../../models/styles';
-import type { DivAttributes } from '../div-attributes';
-import type { BaseElement } from '../../../base/base-element';
+import { FigmaNodeConfig, FigmaNode } from "../../../../models/figma-node";
+import { Styles } from "../../../../models/styles";
+import type { DivAttributes } from "../div-attributes";
+import type { BaseElement } from "../../../base/base-element";
 
 /**
  * div要素の型定義
  * BaseElementを継承した専用の型
  */
-export interface DivElement extends BaseElement<'div'> {
+export interface DivElement extends BaseElement<"div", DivAttributes> {
   attributes: DivAttributes;
   children: DivElement[] | [];
 }
@@ -18,32 +18,32 @@ export interface DivElement extends BaseElement<'div'> {
 export const DivElement = {
   isDivElement(node: unknown): node is DivElement {
     return (
-      typeof node === 'object' &&
+      typeof node === "object" &&
       node !== null &&
-      'type' in node &&
-      'tagName' in node &&
-      node.type === 'element' &&
-      node.tagName === 'div'
+      "type" in node &&
+      "tagName" in node &&
+      node.type === "element" &&
+      node.tagName === "div"
     );
   },
 
   create(attributes: Partial<DivAttributes> = {}): DivElement {
     return {
-      type: 'element',
-      tagName: 'div',
+      type: "element",
+      tagName: "div",
       attributes: attributes as DivAttributes,
-      children: []
+      children: [],
     };
   },
 
   toFigmaNode(element: DivElement): FigmaNodeConfig {
-    let config = FigmaNode.createFrame('div');
+    let config = FigmaNode.createFrame("div");
 
     // HTML要素のデフォルト設定を適用
     config = FigmaNodeConfig.applyHtmlElementDefaults(
       config,
-      'div',
-      element.attributes
+      "div",
+      element.attributes,
     );
 
     // スタイルがない場合は早期リターン
@@ -68,19 +68,19 @@ export const DivElement = {
     // Flexboxスタイルを適用（常に実行、内部で判定）
     config = FigmaNodeConfig.applyFlexboxStyles(
       config,
-      Styles.extractFlexboxOptions(styles)
+      Styles.extractFlexboxOptions(styles),
     );
 
     // ボーダースタイルを適用（常に実行、内部で判定）
     config = FigmaNodeConfig.applyBorderStyles(
       config,
-      Styles.extractBorderOptions(styles)
+      Styles.extractBorderOptions(styles),
     );
 
     // サイズスタイルを適用（常に実行、内部で判定）
     config = FigmaNodeConfig.applySizeStyles(
       config,
-      Styles.extractSizeOptions(styles)
+      Styles.extractSizeOptions(styles),
     );
 
     return config;
@@ -91,20 +91,21 @@ export const DivElement = {
       // 互換性のためのHTMLNodeからの変換
       if (
         node !== null &&
-        typeof node === 'object' &&
-        'type' in node &&
-        'tagName' in node &&
-        node.type === 'element' &&
-        node.tagName === 'div'
+        typeof node === "object" &&
+        "type" in node &&
+        "tagName" in node &&
+        node.type === "element" &&
+        node.tagName === "div"
       ) {
-        const attributes = 'attributes' in node && typeof node.attributes === 'object' 
-          ? node.attributes as Partial<DivAttributes>
-          : {};
+        const attributes =
+          "attributes" in node && typeof node.attributes === "object"
+            ? (node.attributes as Partial<DivAttributes>)
+            : {};
         const element = this.create(attributes);
         return this.toFigmaNode(element);
       }
       return null;
     }
     return this.toFigmaNode(node);
-  }
+  },
 };

--- a/src/converter/elements/container/section/section-element/section-element.ts
+++ b/src/converter/elements/container/section/section-element/section-element.ts
@@ -8,7 +8,8 @@ import type { BaseElement } from "../../../base/base-element";
  * BaseElementを継承した専用の型
  * HTML5のセマンティック要素として文書のセクションを表す
  */
-export interface SectionElement extends BaseElement<"section"> {
+export interface SectionElement
+  extends BaseElement<"section", SectionAttributes> {
   attributes: SectionAttributes;
   children: SectionElement[] | [];
 }
@@ -74,7 +75,7 @@ export const SectionElement = {
     config = FigmaNodeConfig.applyHtmlElementDefaults(
       config,
       "section",
-      element.attributes
+      element.attributes,
     );
 
     // スタイルがない場合は早期リターン
@@ -99,19 +100,19 @@ export const SectionElement = {
     // Flexboxスタイルを適用（常に実行、内部で判定）
     config = FigmaNodeConfig.applyFlexboxStyles(
       config,
-      Styles.extractFlexboxOptions(styles)
+      Styles.extractFlexboxOptions(styles),
     );
 
     // ボーダースタイルを適用（常に実行、内部で判定）
     config = FigmaNodeConfig.applyBorderStyles(
       config,
-      Styles.extractBorderOptions(styles)
+      Styles.extractBorderOptions(styles),
     );
 
     // サイズスタイルを適用（常に実行、内部で判定）
     config = FigmaNodeConfig.applySizeStyles(
       config,
-      Styles.extractSizeOptions(styles)
+      Styles.extractSizeOptions(styles),
     );
 
     return config;

--- a/src/converter/elements/text/span/span-element/span-element.ts
+++ b/src/converter/elements/text/span/span-element/span-element.ts
@@ -1,13 +1,12 @@
 import type { HTMLNode } from "../../../../models/html-node/html-node";
+import type { BaseElement } from "../../../base";
 import type { SpanAttributes } from "../span-attributes";
 
 /**
  * span要素の型定義
  * HTMLのspan（インライン）要素を表現します
  */
-export interface SpanElement {
-  type: "element";
-  tagName: "span";
+export interface SpanElement extends BaseElement<"span", SpanAttributes> {
   attributes: SpanAttributes;
   children?: HTMLNode[];
 }

--- a/src/converter/models/html-node/__tests__/html-node.extractText.test.ts
+++ b/src/converter/models/html-node/__tests__/html-node.extractText.test.ts
@@ -1,0 +1,341 @@
+import { test, expect } from "vitest";
+import { HTMLNode } from "../html-node";
+
+// ========================================
+// extractText のテスト
+// ========================================
+
+test("HTMLNode.extractText - テキストノードからテキストを抽出する", () => {
+  const node = {
+    type: "text" as const,
+    textContent: "Hello World",
+  };
+
+  const result = HTMLNode.extractText(node);
+
+  expect(result).toBe("Hello World");
+});
+
+test("HTMLNode.extractText - 空のテキストノードから空文字列を返す", () => {
+  const node = {
+    type: "text" as const,
+    textContent: "",
+  };
+
+  const result = HTMLNode.extractText(node);
+
+  expect(result).toBe("");
+});
+
+test("HTMLNode.extractText - textContentがundefinedのテキストノードから空文字列を返す", () => {
+  const node = {
+    type: "text" as const,
+  };
+
+  const result = HTMLNode.extractText(node);
+
+  expect(result).toBe("");
+});
+
+test("HTMLNode.extractText - 子要素を持つ要素からテキストを抽出する", () => {
+  const node = {
+    type: "element" as const,
+    tagName: "div",
+    children: [
+      { type: "text" as const, textContent: "Hello " },
+      { type: "text" as const, textContent: "World" },
+    ],
+  };
+
+  const result = HTMLNode.extractText(node);
+
+  expect(result).toBe("Hello World");
+});
+
+test("HTMLNode.extractText - ネストした要素からテキストを再帰的に抽出する", () => {
+  const node = {
+    type: "element" as const,
+    tagName: "div",
+    children: [
+      { type: "text" as const, textContent: "This is " },
+      {
+        type: "element" as const,
+        tagName: "span",
+        children: [{ type: "text" as const, textContent: "nested" }],
+      },
+      { type: "text" as const, textContent: " text" },
+    ],
+  };
+
+  const result = HTMLNode.extractText(node);
+
+  expect(result).toBe("This is nested text");
+});
+
+test("HTMLNode.extractText - 深くネストした構造からテキストを抽出する", () => {
+  const node = {
+    type: "element" as const,
+    tagName: "div",
+    children: [
+      {
+        type: "element" as const,
+        tagName: "p",
+        children: [
+          { type: "text" as const, textContent: "First " },
+          {
+            type: "element" as const,
+            tagName: "strong",
+            children: [
+              { type: "text" as const, textContent: "bold" },
+              {
+                type: "element" as const,
+                tagName: "em",
+                children: [{ type: "text" as const, textContent: " italic" }],
+              },
+            ],
+          },
+          { type: "text" as const, textContent: " text" },
+        ],
+      },
+    ],
+  };
+
+  const result = HTMLNode.extractText(node);
+
+  expect(result).toBe("First bold italic text");
+});
+
+test("HTMLNode.extractText - 子要素がない要素から空文字列を返す", () => {
+  const node = {
+    type: "element" as const,
+    tagName: "div",
+    children: [],
+  };
+
+  const result = HTMLNode.extractText(node);
+
+  expect(result).toBe("");
+});
+
+test("HTMLNode.extractText - childrenがundefinedの要素から空文字列を返す", () => {
+  const node = {
+    type: "element" as const,
+    tagName: "div",
+  };
+
+  const result = HTMLNode.extractText(node);
+
+  expect(result).toBe("");
+});
+
+test("HTMLNode.extractText - nullを渡すと空文字列を返す", () => {
+  const result = HTMLNode.extractText(null);
+
+  expect(result).toBe("");
+});
+
+test("HTMLNode.extractText - undefinedを渡すと空文字列を返す", () => {
+  const result = HTMLNode.extractText(undefined);
+
+  expect(result).toBe("");
+});
+
+// ========================================
+// 循環参照の処理
+// ========================================
+
+test("HTMLNode.extractText - 循環参照を持つ構造を処理できる", () => {
+  const child: HTMLNode = {
+    type: "element",
+    tagName: "span",
+    children: [],
+  };
+
+  const parent: HTMLNode = {
+    type: "element",
+    tagName: "div",
+    children: [
+      { type: "text", textContent: "Start " },
+      child,
+      { type: "text", textContent: " End" },
+    ],
+  };
+
+  // 循環参照を作成
+  child.children!.push(parent);
+
+  const result = HTMLNode.extractText(parent);
+
+  expect(result).toBe("Start  End");
+});
+
+test("HTMLNode.extractText - 自己参照を持つ構造を処理できる", () => {
+  const node: HTMLNode = {
+    type: "element",
+    tagName: "div",
+    children: [{ type: "text", textContent: "Text" }],
+  };
+
+  // 自己参照を追加
+  node.children!.push(node);
+
+  const result = HTMLNode.extractText(node);
+
+  expect(result).toBe("Text");
+});
+
+// ========================================
+// extractTextFromNodes のテスト
+// ========================================
+
+test("HTMLNode.extractTextFromNodes - 複数のノードからテキストを抽出する", () => {
+  const nodes = [
+    { type: "text" as const, textContent: "Hello" },
+    { type: "text" as const, textContent: " " },
+    { type: "text" as const, textContent: "World" },
+  ];
+
+  const result = HTMLNode.extractTextFromNodes(nodes);
+
+  expect(result).toBe("Hello World");
+});
+
+test("HTMLNode.extractTextFromNodes - 混在するノード型からテキストを抽出する", () => {
+  const nodes = [
+    { type: "text" as const, textContent: "Start " },
+    {
+      type: "element" as const,
+      tagName: "span",
+      children: [{ type: "text" as const, textContent: "middle" }],
+    },
+    { type: "text" as const, textContent: " end" },
+  ];
+
+  const result = HTMLNode.extractTextFromNodes(nodes);
+
+  expect(result).toBe("Start middle end");
+});
+
+test("HTMLNode.extractTextFromNodes - nullやundefinedを含む配列を処理する", () => {
+  const nodes = [
+    { type: "text" as const, textContent: "Hello" },
+    null,
+    { type: "text" as const, textContent: " " },
+    undefined,
+    { type: "text" as const, textContent: "World" },
+  ];
+
+  const result = HTMLNode.extractTextFromNodes(nodes);
+
+  expect(result).toBe("Hello World");
+});
+
+test("HTMLNode.extractTextFromNodes - 空の配列から空文字列を返す", () => {
+  const result = HTMLNode.extractTextFromNodes([]);
+
+  expect(result).toBe("");
+});
+
+test("HTMLNode.extractTextFromNodes - 全てnullの配列から空文字列を返す", () => {
+  const nodes = [null, undefined, null];
+
+  const result = HTMLNode.extractTextFromNodes(nodes);
+
+  expect(result).toBe("");
+});
+
+// ========================================
+// 複雑な実使用例
+// ========================================
+
+test("HTMLNode.extractText - HTMLのような構造からテキストを抽出する", () => {
+  const node = {
+    type: "element" as const,
+    tagName: "article",
+    children: [
+      {
+        type: "element" as const,
+        tagName: "h1",
+        children: [{ type: "text" as const, textContent: "Title" }],
+      },
+      {
+        type: "element" as const,
+        tagName: "p",
+        children: [
+          { type: "text" as const, textContent: "This is a " },
+          {
+            type: "element" as const,
+            tagName: "a",
+            children: [{ type: "text" as const, textContent: "link" }],
+          },
+          { type: "text" as const, textContent: " in a paragraph." },
+        ],
+      },
+      {
+        type: "element" as const,
+        tagName: "ul",
+        children: [
+          {
+            type: "element" as const,
+            tagName: "li",
+            children: [{ type: "text" as const, textContent: "Item 1" }],
+          },
+          {
+            type: "element" as const,
+            tagName: "li",
+            children: [{ type: "text" as const, textContent: "Item 2" }],
+          },
+        ],
+      },
+    ],
+  };
+
+  const result = HTMLNode.extractText(node);
+
+  expect(result).toBe("TitleThis is a link in a paragraph.Item 1Item 2");
+});
+
+// ========================================
+// コメントノードの処理
+// ========================================
+
+test("HTMLNode.extractText - コメントノードを無視する", () => {
+  const node = {
+    type: "element" as const,
+    tagName: "div",
+    children: [
+      { type: "text" as const, textContent: "Before " },
+      { type: "comment" as const, textContent: "This is a comment" },
+      { type: "text" as const, textContent: "After" },
+    ],
+  };
+
+  const result = HTMLNode.extractText(node);
+
+  expect(result).toBe("Before After");
+});
+
+// ========================================
+// 後方互換性のテスト
+// ========================================
+
+test("HTMLNode.extractTextContent - extractTextと同じ結果を返す（後方互換性）", () => {
+  const node = {
+    type: "element" as const,
+    tagName: "div",
+    children: [
+      { type: "text" as const, textContent: "Hello " },
+      {
+        type: "element" as const,
+        tagName: "span",
+        children: [{ type: "text" as const, textContent: "World" }],
+      },
+    ],
+  };
+
+  const extractTextResult = HTMLNode.extractText(node);
+  const extractTextContentResult = HTMLNode.extractTextContent(node);
+
+  expect(extractTextContentResult).toBe(extractTextResult);
+  expect(extractTextContentResult).toBe("Hello World");
+});

--- a/src/converter/models/html-node/html-node.ts
+++ b/src/converter/models/html-node/html-node.ts
@@ -181,7 +181,26 @@ export const HTMLNode = {
   },
 
   // 要素からテキストコンテンツを抽出（後方互換性のため残す）
-  extractTextContent(element: HTMLNode): string {
-    return this.extractText(element);
+  extractTextContent(element: unknown): string {
+    // 旧形式のノード（contentプロパティを持つ）の場合
+    if (element && typeof element === "object") {
+      const obj = element as Record<string, unknown>;
+      // 直接contentプロパティを持つ場合
+      if ("content" in obj && typeof obj.content === "string") {
+        return obj.content;
+      }
+      // テキストノードで、textContentプロパティを持つ場合
+      if (obj.type === "text" && typeof obj.textContent === "string") {
+        return obj.textContent;
+      }
+      // 子要素を持つ場合、再帰的に処理
+      if (obj.children && Array.isArray(obj.children)) {
+        return obj.children
+          .map((child: unknown) => this.extractTextContent(child))
+          .join("");
+      }
+    }
+    // 標準のextractTextにフォールバック
+    return this.extractText(element as HTMLNode);
   },
 };

--- a/src/converter/models/html-node/html-node.ts
+++ b/src/converter/models/html-node/html-node.ts
@@ -184,23 +184,54 @@ export const HTMLNode = {
   extractTextContent(element: unknown): string {
     // 旧形式のノード（contentプロパティを持つ）の場合
     if (element && typeof element === "object") {
-      const obj = element as Record<string, unknown>;
-      // 直接contentプロパティを持つ場合
-      if ("content" in obj && typeof obj.content === "string") {
-        return obj.content;
+      // 型ガードを使用して安全にプロパティアクセス
+      if (this.hasContentProperty(element)) {
+        return element.content;
       }
       // テキストノードで、textContentプロパティを持つ場合
-      if (obj.type === "text" && typeof obj.textContent === "string") {
-        return obj.textContent;
+      if (this.hasTextContentProperty(element) && element.type === "text") {
+        return element.textContent;
       }
       // 子要素を持つ場合、再帰的に処理
-      if (obj.children && Array.isArray(obj.children)) {
-        return obj.children
+      if (this.hasChildrenProperty(element)) {
+        return element.children
           .map((child: unknown) => this.extractTextContent(child))
           .join("");
       }
     }
     // 標準のextractTextにフォールバック
     return this.extractText(element as HTMLNode);
+  },
+
+  // 型ガード：contentプロパティを持つかチェック
+  hasContentProperty(
+    obj: object,
+  ): obj is { content: string } & Record<string, unknown> {
+    return (
+      "content" in obj &&
+      typeof (obj as { content: unknown }).content === "string"
+    );
+  },
+
+  // 型ガード：textContentプロパティを持つかチェック
+  hasTextContentProperty(
+    obj: object,
+  ): obj is { textContent: string; type: string } & Record<string, unknown> {
+    return (
+      "textContent" in obj &&
+      typeof (obj as { textContent: unknown }).textContent === "string" &&
+      "type" in obj &&
+      typeof (obj as { type: unknown }).type === "string"
+    );
+  },
+
+  // 型ガード：childrenプロパティを持つかチェック
+  hasChildrenProperty(
+    obj: object,
+  ): obj is { children: unknown[] } & Record<string, unknown> {
+    return (
+      "children" in obj &&
+      Array.isArray((obj as { children: unknown }).children)
+    );
   },
 };

--- a/src/converter/utils/node-name-builder.test.ts
+++ b/src/converter/utils/node-name-builder.test.ts
@@ -1,0 +1,440 @@
+import { test, expect } from "vitest";
+import { buildNodeName } from "./node-name-builder";
+import type { HTMLNode } from "../models/html-node/html-node";
+
+// ========================================
+// テストヘルパー関数
+// ========================================
+
+function createElementNode(
+  tagName: string,
+  attributes?: Record<string, string>,
+): HTMLNode {
+  return {
+    type: "element",
+    tagName,
+    attributes,
+  };
+}
+
+// ========================================
+// 基本的なタグ名のみのケース
+// ========================================
+
+test('buildNodeName - div要素（属性なし）を渡すと、"div"を返す', () => {
+  // Arrange
+  const node = createElementNode("div");
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("div");
+});
+
+test('buildNodeName - span要素（属性なし）を渡すと、"span"を返す', () => {
+  // Arrange
+  const node = createElementNode("span");
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("span");
+});
+
+// ========================================
+// パラメータ化テスト: 複数のタグ名
+// ========================================
+
+test.each([
+  { tagName: "p", expected: "p" },
+  { tagName: "section", expected: "section" },
+  { tagName: "article", expected: "article" },
+  { tagName: "header", expected: "header" },
+  { tagName: "footer", expected: "footer" },
+  { tagName: "nav", expected: "nav" },
+  { tagName: "main", expected: "main" },
+  { tagName: "aside", expected: "aside" },
+  { tagName: "h1", expected: "h1" },
+  { tagName: "h2", expected: "h2" },
+  { tagName: "h3", expected: "h3" },
+  { tagName: "h4", expected: "h4" },
+  { tagName: "h5", expected: "h5" },
+  { tagName: "h6", expected: "h6" },
+])(
+  'buildNodeName - $tagName要素（属性なし）を渡すと、"$expected"を返す',
+  ({ tagName, expected }) => {
+    // Arrange
+    const node = createElementNode(tagName);
+
+    // Act
+    const result = buildNodeName(node);
+
+    // Assert
+    expect(result).toBe(expected);
+  },
+);
+
+// ========================================
+// ID属性のケース
+// ========================================
+
+test('buildNodeName - ID属性"main-container"を持つdiv要素を渡すと、"div#main-container"を返す', () => {
+  // Arrange
+  const node = createElementNode("div", { id: "main-container" });
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("div#main-container");
+});
+
+test('buildNodeName - ID属性"highlight"を持つspan要素を渡すと、"span#highlight"を返す', () => {
+  // Arrange
+  const node = createElementNode("span", { id: "highlight" });
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("span#highlight");
+});
+
+// ========================================
+// 特殊文字を含むID
+// ========================================
+
+test.each([
+  { id: "test-123", expected: "div#test-123" },
+  { id: "user_profile", expected: "div#user_profile" },
+  { id: "item-001-description", expected: "div#item-001-description" },
+  { id: "123", expected: "div#123" },
+  { id: "_underscore", expected: "div#_underscore" },
+])(
+  'buildNodeName - 特殊文字を含むID"$id"を正しく処理する',
+  ({ id, expected }) => {
+    // Arrange
+    const node = createElementNode("div", { id });
+
+    // Act
+    const result = buildNodeName(node);
+
+    // Assert
+    expect(result).toBe(expected);
+  },
+);
+
+// ========================================
+// クラス属性のケース
+// ========================================
+
+test('buildNodeName - 単一クラス"container"を持つdiv要素を渡すと、"div.container"を返す', () => {
+  // Arrange
+  const node = createElementNode("div", { class: "container" });
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("div.container");
+});
+
+test('buildNodeName - 複数クラス"text-bold text-primary highlight"を持つspan要素を渡すと、"span.text-bold.text-primary.highlight"を返す', () => {
+  // Arrange
+  const node = createElementNode("span", {
+    class: "text-bold text-primary highlight",
+  });
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("span.text-bold.text-primary.highlight");
+});
+
+test("buildNodeName - クラス文字列に余分な空白がある場合、適切にトリミングして処理する", () => {
+  // Arrange
+  const node = createElementNode("p", {
+    class: "  paragraph   main   ",
+  });
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("p.paragraph.main");
+});
+
+// ========================================
+// 特殊文字を含むクラス名
+// ========================================
+
+test.each([
+  {
+    className: "btn--primary",
+    expected: "button.btn--primary",
+  },
+  {
+    className: "text-lg-center",
+    expected: "button.text-lg-center",
+  },
+  {
+    className: "is-active has-dropdown",
+    expected: "button.is-active.has-dropdown",
+  },
+  {
+    className: "col-md-6 col-lg-4",
+    expected: "button.col-md-6.col-lg-4",
+  },
+])(
+  'buildNodeName - 特殊文字を含むクラス"$className"を正しく処理する',
+  ({ className, expected }) => {
+    // Arrange
+    const node = createElementNode("button", { class: className });
+
+    // Act
+    const result = buildNodeName(node);
+
+    // Assert
+    expect(result).toBe(expected);
+  },
+);
+
+// ========================================
+// ID+クラスの複合ケース
+// ========================================
+
+test('buildNodeName - ID"header"とクラス"navbar"を持つdiv要素を渡すと、"div#header.navbar"を返す', () => {
+  // Arrange
+  const node = createElementNode("div", {
+    id: "header",
+    class: "navbar",
+  });
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("div#header.navbar");
+});
+
+test('buildNodeName - ID"content"と複数クラス"main-section active visible"を持つsection要素を渡すと、"section#content.main-section.active.visible"を返す', () => {
+  // Arrange
+  const node = createElementNode("section", {
+    id: "content",
+    class: "main-section active visible",
+  });
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("section#content.main-section.active.visible");
+});
+
+// ========================================
+// エッジケース: 属性の状態
+// ========================================
+
+test("buildNodeName - attributesがundefinedの要素を渡すと、タグ名のみを返す", () => {
+  // Arrange
+  const node: HTMLNode = {
+    type: "element",
+    tagName: "article",
+    attributes: undefined,
+  };
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("article");
+});
+
+test("buildNodeName - 空のattributesオブジェクトを持つ要素を渡すと、タグ名のみを返す", () => {
+  // Arrange
+  const node = createElementNode("h1", {});
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("h1");
+});
+
+test("buildNodeName - 空文字のclass属性を持つ要素を渡すと、タグ名のみを返す", () => {
+  // Arrange
+  const node = createElementNode("p", { class: "" });
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("p");
+});
+
+test("buildNodeName - 空白のみのclass属性を持つ要素を渡すと、タグ名のみを返す", () => {
+  // Arrange
+  const node = createElementNode("span", { class: "   " });
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("span");
+});
+
+// ========================================
+// エッジケース: null/undefined の属性値
+// ========================================
+
+test("buildNodeName - IDがnullの場合、IDを無視してタグ名のみを返す", () => {
+  // Arrange
+  const node = createElementNode("div", { id: null as any });
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("div");
+});
+
+test("buildNodeName - IDがundefinedの場合、IDを無視してタグ名のみを返す", () => {
+  // Arrange
+  const node = createElementNode("div", { id: undefined as any });
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("div");
+});
+
+test("buildNodeName - クラスがnullの場合、クラスを無視してタグ名のみを返す", () => {
+  // Arrange
+  const node = createElementNode("span", { class: null as any });
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("span");
+});
+
+test("buildNodeName - クラスがundefinedの場合、クラスを無視してタグ名のみを返す", () => {
+  // Arrange
+  const node = createElementNode("span", { class: undefined as any });
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("span");
+});
+
+// ========================================
+// Unicode文字を含むID/クラス
+// ========================================
+
+test("buildNodeName - 日本語を含むIDを正しく処理する", () => {
+  // Arrange
+  const node = createElementNode("div", { id: "ヘッダー" });
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("div#ヘッダー");
+});
+
+test("buildNodeName - 日本語を含むクラス名を正しく処理する", () => {
+  // Arrange
+  const node = createElementNode("div", { class: "メイン コンテンツ" });
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("div.メイン.コンテンツ");
+});
+
+test("buildNodeName - 絵文字を含むID/クラスを正しく処理する", () => {
+  // Arrange
+  const node = createElementNode("div", {
+    id: "emoji-🎉",
+    class: "icon-💡 highlight-✨",
+  });
+
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe("div#emoji-🎉.icon-💡.highlight-✨");
+});
+
+// ========================================
+// パフォーマンステスト: 極端に長いクラスリスト
+// ========================================
+
+test("buildNodeName - 100個のクラスを持つ要素でも正しく処理する", () => {
+  // Arrange
+  const classes = Array.from({ length: 100 }, (_, i) => `class-${i}`);
+  const node = createElementNode("div", {
+    class: classes.join(" "),
+  });
+
+  // Act
+  const startTime = performance.now();
+  const result = buildNodeName(node);
+  const endTime = performance.now();
+
+  // Assert
+  expect(result).toBe(`div.${classes.join(".")}`);
+  expect(endTime - startTime).toBeLessThan(10); // 10ms以内に処理完了
+});
+
+// ========================================
+// 実際の使用ケースのシミュレーション
+// ========================================
+
+test.each([
+  {
+    description: "Bootstrap のカード要素",
+    node: createElementNode("div", {
+      id: "product-card",
+      class: "card card-body shadow-sm",
+    }),
+    expected: "div#product-card.card.card-body.shadow-sm",
+  },
+  {
+    description: "React コンポーネントのルート要素",
+    node: createElementNode("div", {
+      id: "root",
+      class: "App",
+    }),
+    expected: "div#root.App",
+  },
+  {
+    description: "BEM 記法のブロック要素",
+    node: createElementNode("nav", {
+      class: "navigation navigation--main",
+    }),
+    expected: "nav.navigation.navigation--main",
+  },
+  {
+    description: "Tailwind CSS のユーティリティクラス",
+    node: createElementNode("button", {
+      class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600",
+    }),
+    expected:
+      "button.px-4.py-2.bg-blue-500.text-white.rounded.hover:bg-blue-600",
+  },
+])("buildNodeName - 実使用例: $description", ({ node, expected }) => {
+  // Act
+  const result = buildNodeName(node);
+
+  // Assert
+  expect(result).toBe(expected);
+});

--- a/src/converter/utils/node-name-builder.test.ts
+++ b/src/converter/utils/node-name-builder.test.ts
@@ -292,7 +292,7 @@ test("buildNodeName - 空白のみのclass属性を持つ要素を渡すと、�
 
 test("buildNodeName - IDがnullの場合、IDを無視してタグ名のみを返す", () => {
   // Arrange
-  const node = createElementNode("div", { id: null as any });
+  const node = createElementNode("div", { id: null as unknown as string });
 
   // Act
   const result = buildNodeName(node);
@@ -303,7 +303,7 @@ test("buildNodeName - IDがnullの場合、IDを無視してタグ名のみを�
 
 test("buildNodeName - IDがundefinedの場合、IDを無視してタグ名のみを返す", () => {
   // Arrange
-  const node = createElementNode("div", { id: undefined as any });
+  const node = createElementNode("div", { id: undefined as unknown as string });
 
   // Act
   const result = buildNodeName(node);
@@ -314,7 +314,7 @@ test("buildNodeName - IDがundefinedの場合、IDを無視してタグ名のみ
 
 test("buildNodeName - クラスがnullの場合、クラスを無視してタグ名のみを返す", () => {
   // Arrange
-  const node = createElementNode("span", { class: null as any });
+  const node = createElementNode("span", { class: null as unknown as string });
 
   // Act
   const result = buildNodeName(node);
@@ -325,7 +325,9 @@ test("buildNodeName - クラスがnullの場合、クラスを無視してタグ
 
 test("buildNodeName - クラスがundefinedの場合、クラスを無視してタグ名のみを返す", () => {
   // Arrange
-  const node = createElementNode("span", { class: undefined as any });
+  const node = createElementNode("span", {
+    class: undefined as unknown as string,
+  });
 
   // Act
   const result = buildNodeName(node);

--- a/src/converter/utils/node-name-builder.ts
+++ b/src/converter/utils/node-name-builder.ts
@@ -1,0 +1,40 @@
+import type { BaseElement } from "../elements/base";
+
+/**
+ * BaseElement から Figma のノード名を生成します
+ *
+ * @param element - BaseElement（attributesを含む場合がある）
+ * @returns タグ名、ID、クラス名を組み合わせたノード名
+ *
+ * @example
+ * - タグ名のみ: buildNodeName(element) → "div"
+ * - ID付き: buildNodeName({ ...element, attributes: { id: "header" } }) → "div#header"
+ * - クラス付き: buildNodeName({ ...element, attributes: { class: "container" } }) → "div.container"
+ * - ID+クラス: buildNodeName({ ...element, attributes: { id: "header", class: "navbar" } }) → "div#header.navbar"
+ */
+export function buildNodeName<T extends string, A = Record<string, unknown>>(
+  element: BaseElement<T, A>
+): string {
+  let name: string = element.tagName;
+
+  // attributes が存在する場合のみ処理
+  if (element.attributes) {
+    const attrs = element.attributes as Record<string, unknown>;
+
+    // ID属性を追加
+    if (attrs.id) {
+      name += `#${attrs.id}`;
+    }
+
+    // クラス属性を追加
+    if (attrs.class) {
+      const classString = String(attrs.class);
+      const classes = classString.split(" ").filter(Boolean);
+      if (classes.length > 0) {
+        name += `.${classes.join(".")}`;
+      }
+    }
+  }
+
+  return name;
+}

--- a/src/converter/utils/node-name-builder.ts
+++ b/src/converter/utils/node-name-builder.ts
@@ -1,5 +1,12 @@
 import type { BaseElement } from "../elements/base";
 
+// 属性の型制約を定義
+type NodeNameAttributes = {
+  id?: string | unknown;
+  class?: string | unknown;
+  [key: string]: unknown;
+};
+
 /**
  * BaseElement から Figma のノード名を生成します
  *
@@ -12,24 +19,25 @@ import type { BaseElement } from "../elements/base";
  * - クラス付き: buildNodeName({ ...element, attributes: { class: "container" } }) → "div.container"
  * - ID+クラス: buildNodeName({ ...element, attributes: { id: "header", class: "navbar" } }) → "div#header.navbar"
  */
-export function buildNodeName<T extends string, A = Record<string, unknown>>(
-  element: BaseElement<T, A>
-): string {
+export function buildNodeName<
+  T extends string,
+  A extends NodeNameAttributes = NodeNameAttributes,
+>(element: BaseElement<T, A>): string {
   let name: string = element.tagName;
 
   // attributes が存在する場合のみ処理
   if (element.attributes) {
-    const attrs = element.attributes as Record<string, unknown>;
+    // 型制約により安全にアクセス可能
+    const attrs = element.attributes;
 
-    // ID属性を追加
-    if (attrs.id) {
+    // ID属性を追加（型安全にチェック）
+    if (attrs.id && typeof attrs.id === "string") {
       name += `#${attrs.id}`;
     }
 
-    // クラス属性を追加
-    if (attrs.class) {
-      const classString = String(attrs.class);
-      const classes = classString.split(" ").filter(Boolean);
+    // クラス属性を追加（型安全にチェック）
+    if (attrs.class && typeof attrs.class === "string") {
+      const classes = attrs.class.split(" ").filter(Boolean);
       if (classes.length > 0) {
         name += `.${classes.join(".")}`;
       }


### PR DESCRIPTION
## 概要

buildNodeName関数を汎用的なユーティリティとして抽出し、BaseElement型の改善、HTMLNodeへのテキスト抽出機能の追加を行いました。

## 変更内容

### 1. BaseElement型の改善
- ジェネリック型パラメータ`A`を追加し、各要素が独自の属性型を定義可能に
- `attributes`プロパティをオプショナルで追加

### 2. buildNodeName関数の汎用化
- span-converterから独立したユーティリティ関数として抽出
- AnyNode型と後方互換性コードを削除し、シンプルな実装に
- 48個の包括的なテストケースを追加

### 3. HTMLNodeへのテキスト抽出機能追加
- `extractText()` - 単一ノードからテキスト抽出
- `extractTextFromNodes()` - 複数ノードからテキスト抽出
- 循環参照対策付きで安全な実装
- 20個のテストケースで動作を保証

### 4. span-converterのリファクタリング
- 105行のコードを削除し、共通機能を利用
- HTMLNode.extractTextFromNodesを使用

## テスト結果

- ✅ 全134個のテストがパス
- ✅ TypeScript型チェック成功
- ✅ ESLintチェック成功

## 影響範囲

- `src/converter/elements/base/base-element/base-element.ts`
- `src/converter/elements/text/span/`
- `src/converter/elements/container/div/`
- `src/converter/elements/container/section/`
- `src/converter/models/html-node/`
- `src/converter/utils/node-name-builder.ts` (新規)

## コミット履歴

- ♻️ BaseElementにジェネリック型パラメータでattributes属性を追加
- ✨ buildNodeName関数をユーティリティとして新規実装
- ✨ HTMLNodeにテキスト抽出機能を追加
- ♻️ 要素型定義をBaseElementジェネリック型対応に改善
- ♻️ span-converterを共通機能利用に変更