### PR TITLE
♻️ [Refactoring]: 型定義の統一とbuildNodeName関数の改善

### DIFF
--- a/src/converter/elements/base/base-element/base-element.ts
+++ b/src/converter/elements/base/base-element/base-element.ts
@@ -1,11 +1,13 @@
+import type { GlobalAttributes } from "../global-attributes/global-attributes";
+
 /**
  * HTML要素の基底インターフェース
  * 全てのHTML要素型はこのインターフェースを拡張する
  *
  * @template T - HTML要素のタグ名
- * @template A - 属性の型（デフォルトはRecord<string, unknown>）
+ * @template A - 属性の型（デフォルトはGlobalAttributes）
  */
-export interface BaseElement<T extends string, A = Record<string, unknown>> {
+export interface BaseElement<T extends string, A = GlobalAttributes> {
   /**
    * ノードタイプ（常に'element'）
    */

--- a/src/converter/utils/node-name-builder.test.ts
+++ b/src/converter/utils/node-name-builder.test.ts
@@ -1,15 +1,16 @@
 import { test, expect } from "vitest";
 import { buildNodeName } from "./node-name-builder";
-import type { HTMLNode } from "../models/html-node/html-node";
+import type { BaseElement } from "../elements/base";
+import type { GlobalAttributes } from "../elements/base/global-attributes/global-attributes";
 
 // ========================================
 // テストヘルパー関数
 // ========================================
 
-function createElementNode(
-  tagName: string,
-  attributes?: Record<string, string>,
-): HTMLNode {
+function createElementNode<T extends string>(
+  tagName: T,
+  attributes?: GlobalAttributes,
+): BaseElement<T, GlobalAttributes> {
   return {
     type: "element",
     tagName,
@@ -240,7 +241,7 @@ test('buildNodeName - ID"content"と複数クラス"main-section active visible"
 
 test("buildNodeName - attributesがundefinedの要素を渡すと、タグ名のみを返す", () => {
   // Arrange
-  const node: HTMLNode = {
+  const node: BaseElement<"article", GlobalAttributes> = {
     type: "element",
     tagName: "article",
     attributes: undefined,

--- a/src/converter/utils/node-name-builder.ts
+++ b/src/converter/utils/node-name-builder.ts
@@ -1,11 +1,5 @@
 import type { BaseElement } from "../elements/base";
-
-// 属性の型制約を定義
-type NodeNameAttributes = {
-  id?: string | unknown;
-  class?: string | unknown;
-  [key: string]: unknown;
-};
+import type { GlobalAttributes } from "../elements/base/global-attributes/global-attributes";
 
 /**
  * BaseElement から Figma のノード名を生成します
@@ -21,26 +15,26 @@ type NodeNameAttributes = {
  */
 export function buildNodeName<
   T extends string,
-  A extends NodeNameAttributes = NodeNameAttributes,
+  A extends GlobalAttributes = GlobalAttributes,
 >(element: BaseElement<T, A>): string {
+  if (!element.attributes) {
+    return element.tagName;
+  }
+
   let name: string = element.tagName;
+  const attrs = element.attributes;
 
-  // attributes が存在する場合のみ処理
-  if (element.attributes) {
-    // 型制約により安全にアクセス可能
-    const attrs = element.attributes;
+  if (attrs.id) {
+    name += `#${attrs.id}`;
+  }
 
-    // ID属性を追加（型安全にチェック）
-    if (attrs.id && typeof attrs.id === "string") {
-      name += `#${attrs.id}`;
-    }
-
-    // クラス属性を追加（型安全にチェック）
-    if (attrs.class && typeof attrs.class === "string") {
-      const classes = attrs.class.split(" ").filter(Boolean);
-      if (classes.length > 0) {
-        name += `.${classes.join(".")}`;
-      }
+  if (attrs.class) {
+    // 連続する空白がある場合にドット記法が壊れるのを防ぐ
+    const classes = attrs.class
+      .split(" ")
+      .filter((className) => className !== "");
+    if (classes.length > 0) {
+      name += `.${classes.join(".")}`;
     }
   }
 


### PR DESCRIPTION
## 概要
buildNodeName関数とBaseElement型定義の改善を行いました。型の重複を排除し、コードの可読性と保守性を向上させました。

## 変更内容

### 🔧 型定義の改善
- `NodeNameAttributes`型を削除し、`GlobalAttributes`型に統一
  - 重複した型定義を排除
- `BaseElement`のジェネリック型デフォルトを`GlobalAttributes`に変更
  - より適切なデフォルト型を提供

### ♻️ buildNodeName関数のリファクタリング
- 早期リターンパターンでネストを削減
- 不要な型チェック（`typeof attrs.id === "string"`）を削除
- `filter(Boolean)`を明示的な空文字列チェックに変更
  - `filter(className => className !== "")`で意図を明確化
- 不要なコメントを削除（コードから自明な内容）

### 🧪 テストの更新
- `HTMLNode`型から`BaseElement<T, GlobalAttributes>`型への移行
- テストヘルパー関数の型定義を更新

## 影響範囲
- `src/converter/utils/node-name-builder.ts`
- `src/converter/elements/base/base-element/base-element.ts`
- `src/converter/utils/node-name-builder.test.ts`

## テスト
✅ すべてのテストが正常に通過
✅ 型チェック成功
✅ リンティング成功

## チェックリスト
- [x] コードレビューの準備完了
- [x] テストが通過
- [x] 型安全性の確保
- [x] 不要なコメントの削除