### PR TITLE
♻️ コンパニオンオブジェクトパターンの不要な型エクスポートを削除

### DIFF
--- a/src/converter/elements/list/ul/index.ts
+++ b/src/converter/elements/list/ul/index.ts
@@ -1,6 +1,5 @@
 // Element types and attributes
 export { UlElement } from "./ul-element";
-export type { UlElement as UlElementType } from "./ul-element";
 export type { UlAttributes } from "./ul-attributes";
 
 // Converters

--- a/src/converter/elements/list/ul/ul-element/index.ts
+++ b/src/converter/elements/list/ul/ul-element/index.ts
@@ -1,2 +1,1 @@
 export { UlElement } from "./ul-element";
-export type { UlElement as UlElementType } from "./ul-element";

--- a/src/converter/elements/text/blockquote/blockquote-element/index.ts
+++ b/src/converter/elements/text/blockquote/blockquote-element/index.ts
@@ -1,2 +1,1 @@
 export { BlockquoteElement } from "./blockquote-element";
-export type { BlockquoteElement as BlockquoteElementType } from "./blockquote-element";

--- a/src/converter/elements/text/blockquote/index.ts
+++ b/src/converter/elements/text/blockquote/index.ts
@@ -1,6 +1,5 @@
 export type { BlockquoteAttributes } from "./blockquote-attributes";
 export { BlockquoteElement } from "./blockquote-element";
-export type { BlockquoteElement as BlockquoteElementType } from "./blockquote-element";
 export {
   toFigmaNode,
   mapToFigma,

--- a/src/converter/elements/text/code/code-element/index.ts
+++ b/src/converter/elements/text/code/code-element/index.ts
@@ -1,2 +1,1 @@
 export { CodeElement } from "./code-element";
-export type { CodeElement as CodeElementType } from "./code-element";

--- a/src/converter/elements/text/code/index.ts
+++ b/src/converter/elements/text/code/index.ts
@@ -1,3 +1,2 @@
 export type { CodeAttributes } from "./code-attributes";
 export { CodeElement } from "./code-element";
-export type { CodeElement as CodeElementType } from "./code-element";

--- a/src/converter/elements/text/mark/index.ts
+++ b/src/converter/elements/text/mark/index.ts
@@ -3,4 +3,3 @@ export type { MarkAttributes } from "./mark-attributes";
 
 // mark-element
 export { MarkElement } from "./mark-element";
-export type { MarkElement as MarkElementType } from "./mark-element";

--- a/src/converter/elements/text/mark/mark-element/index.ts
+++ b/src/converter/elements/text/mark/mark-element/index.ts
@@ -1,2 +1,1 @@
 export { MarkElement } from "./mark-element";
-export type { MarkElement as MarkElementType } from "./mark-element";

--- a/src/converter/elements/text/pre/index.ts
+++ b/src/converter/elements/text/pre/index.ts
@@ -1,4 +1,3 @@
 export type { PreAttributes } from "./pre-attributes";
 export { PreElement } from "./pre-element";
-export type { PreElement as PreElementType } from "./pre-element";
 export { toFigmaNode, mapToFigma, PreConverter } from "./pre-converter";

--- a/src/converter/elements/text/pre/pre-element/index.ts
+++ b/src/converter/elements/text/pre/pre-element/index.ts
@@ -1,2 +1,1 @@
 export { PreElement } from "./pre-element";
-export type { PreElement as PreElementType } from "./pre-element";

--- a/src/converter/elements/text/small/index.ts
+++ b/src/converter/elements/text/small/index.ts
@@ -3,4 +3,3 @@ export type { SmallAttributes } from "./small-attributes";
 
 // small-element
 export { SmallElement } from "./small-element";
-export type { SmallElement as SmallElementType } from "./small-element";

--- a/src/converter/elements/text/small/small-element/index.ts
+++ b/src/converter/elements/text/small/small-element/index.ts
@@ -1,2 +1,1 @@
 export { SmallElement } from "./small-element";
-export type { SmallElement as SmallElementType } from "./small-element";


### PR DESCRIPTION
## 📋 概要
TypeScriptのコンパニオンオブジェクトパターンで不要な型エクスポートを削除しました。

## 🎯 修正理由
TypeScriptのコンパニオンオブジェクトパターンでは、値をエクスポートすれば型も自動的に利用可能になります。明示的な型エクスポートは冗長であり、コードをシンプルに保つために削除しました。

## 🔧 修正内容

### 修正前のパターン
```typescript
export { MarkElement } from "./mark-element";
export type { MarkElement } from "./mark-element";  // ❌ 不要
```

### 修正後のパターン
```typescript
export { MarkElement } from "./mark-element";  // ✅ これだけで値と型の両方が使える
```

### 修正対象（12ファイル）
- **mark要素**: `/mark/index.ts`, `/mark-element/index.ts`
- **small要素**: `/small/index.ts`, `/small-element/index.ts`
- **code要素**: `/code/index.ts`, `/code-element/index.ts`
- **pre要素**: `/pre/index.ts`, `/pre-element/index.ts`
- **blockquote要素**: `/blockquote/index.ts`, `/blockquote-element/index.ts`
- **ul要素**: `/ul/index.ts`, `/ul-element/index.ts`

## ✅ テスト
- 全テストがパス
- 型の自動推論が正常に機能することを確認

## 📝 補足
TypeScriptのコンパニオンオブジェクトパターンの正しい使い方に準拠した修正です。この修正により：
- コードがよりシンプルになりました
- TypeScriptの言語機能を適切に活用しています
- メンテナンス性が向上しました

## 🔗 関連PR
- #64 - mark要素の実装（この修正の発見元）