### PR TITLE
✨ [Feature]: SVG polygon/polyline要素の実装

### DIFF
--- a/src/converter/elements/svg/__tests__/svg-shapes.integration.test.ts
+++ b/src/converter/elements/svg/__tests__/svg-shapes.integration.test.ts
@@ -5,6 +5,8 @@ import {
   LineElement,
   EllipseElement,
   PathElement,
+  PolygonElement,
+  PolylineElement,
 } from "../index";
 
 // 複数図形の同時変換
@@ -411,4 +413,157 @@ test("SVG図形統合テスト - 複雑なパスデータ - ベジェ曲線を�
   expect(pathConfig.width).toBeGreaterThan(0);
   expect(pathConfig.height).toBeGreaterThan(0);
   expect(pathConfig.fills?.length).toBe(1);
+});
+
+// Polygon/Polyline統合テスト
+test("SVG図形統合テスト - polygon, polylineを同時に変換 - 全要素が正しいノードタイプで変換される", () => {
+  // Arrange
+  const polygon = PolygonElement.create({
+    points: "100,10 40,198 190,78 10,78 160,198",
+    fill: "#ff0000",
+  });
+
+  const polyline = PolylineElement.create({
+    points: "0,40 40,40 40,80 80,80",
+    stroke: "#0000ff",
+    "stroke-width": 2,
+    fill: "none",
+  });
+
+  // Act
+  const polygonConfig = PolygonElement.toFigmaNode(polygon);
+  const polylineConfig = PolylineElement.toFigmaNode(polyline);
+
+  // Assert
+  expect(polygonConfig.name).toBe("polygon");
+  expect(polygonConfig.type).toBe("FRAME");
+  expect(polylineConfig.name).toBe("polyline");
+  expect(polylineConfig.type).toBe("FRAME");
+});
+
+test("SVG図形統合テスト - polygonの星形 - 正しい境界ボックスが計算される", () => {
+  // Arrange (5点星形)
+  const polygon = PolygonElement.create({
+    points: "100,10 40,198 190,78 10,78 160,198",
+    fill: "#ffff00",
+  });
+
+  // Act
+  const polygonConfig = PolygonElement.toFigmaNode(polygon);
+
+  // Assert
+  expect(polygonConfig.x).toBe(10);
+  expect(polygonConfig.y).toBe(10);
+  expect(polygonConfig.width).toBe(180);
+  expect(polygonConfig.height).toBe(188);
+  expect(polygonConfig.fills?.length).toBe(1);
+});
+
+test("SVG図形統合テスト - polylineの階段パターン - 正しい境界ボックスが計算される", () => {
+  // Arrange
+  const polyline = PolylineElement.create({
+    points: "0,40 40,40 40,80 80,80 80,120 120,120",
+    stroke: "#000000",
+    "stroke-width": 2,
+    fill: "none",
+  });
+
+  // Act
+  const polylineConfig = PolylineElement.toFigmaNode(polyline);
+
+  // Assert
+  expect(polylineConfig.x).toBe(0);
+  expect(polylineConfig.y).toBe(40);
+  expect(polylineConfig.width).toBe(120);
+  expect(polylineConfig.height).toBe(80);
+  expect(polylineConfig.fills).toEqual([]);
+  expect(polylineConfig.strokes?.length).toBe(1);
+});
+
+test("SVG図形統合テスト - polygon/polylineのHTMLNodeライクなオブジェクトをマッピング - 正しく変換される", () => {
+  // Arrange
+  const polygonNode = {
+    type: "element",
+    tagName: "polygon",
+    attributes: { points: "100,10 40,198 190,78" },
+  };
+
+  const polylineNode = {
+    type: "element",
+    tagName: "polyline",
+    attributes: { points: "0,40 40,40 40,80 80,80" },
+  };
+
+  // Act
+  const polygonResult = PolygonElement.mapToFigma(polygonNode);
+  const polygonFromPolyline = PolygonElement.mapToFigma(polylineNode);
+  const polylineResult = PolylineElement.mapToFigma(polylineNode);
+  const polylineFromPolygon = PolylineElement.mapToFigma(polygonNode);
+
+  // Assert
+  expect(polygonResult).not.toBeNull();
+  expect(polygonFromPolyline).toBeNull();
+  expect(polylineResult).not.toBeNull();
+  expect(polylineFromPolygon).toBeNull();
+});
+
+test("SVG図形統合テスト - 全図形にstrokeを設定 - polygon/polyline含め全図形でstrokeが適用される", () => {
+  // Arrange
+  const strokeColor = "#0000ff";
+  const strokeWidth = 3;
+
+  const polygon = PolygonElement.create({
+    points: "100,10 40,198 190,78",
+    fill: "none",
+    stroke: strokeColor,
+    "stroke-width": strokeWidth,
+  });
+
+  const polyline = PolylineElement.create({
+    points: "0,40 40,40 40,80 80,80",
+    fill: "none",
+    stroke: strokeColor,
+    "stroke-width": strokeWidth,
+  });
+
+  const circle = CircleElement.create({
+    cx: 50,
+    cy: 50,
+    r: 25,
+    fill: "none",
+    stroke: strokeColor,
+    "stroke-width": strokeWidth,
+  });
+
+  // Act
+  const polygonConfig = PolygonElement.toFigmaNode(polygon);
+  const polylineConfig = PolylineElement.toFigmaNode(polyline);
+  const circleConfig = CircleElement.toFigmaNode(circle);
+
+  // Assert
+  expect(polygonConfig.strokes?.length).toBe(1);
+  expect(polygonConfig.strokeWeight).toBe(strokeWidth);
+
+  expect(polylineConfig.strokes?.length).toBe(1);
+  expect(polylineConfig.strokeWeight).toBe(strokeWidth);
+
+  expect(circleConfig.strokes?.length).toBe(1);
+  expect(circleConfig.strokeWeight).toBe(strokeWidth);
+});
+
+test("SVG図形統合テスト - 複雑なpolygon座標 - 負の座標を含む場合も正しく計算される", () => {
+  // Arrange
+  const polygon = PolygonElement.create({
+    points: "-50,-50 50,-50 50,50 -50,50",
+    fill: "#ff0000",
+  });
+
+  // Act
+  const polygonConfig = PolygonElement.toFigmaNode(polygon);
+
+  // Assert
+  expect(polygonConfig.x).toBe(-50);
+  expect(polygonConfig.y).toBe(-50);
+  expect(polygonConfig.width).toBe(100);
+  expect(polygonConfig.height).toBe(100);
 });

--- a/src/converter/elements/svg/circle/circle-element/index.ts
+++ b/src/converter/elements/svg/circle/circle-element/index.ts
@@ -1,4 +1,1 @@
-export {
-  CircleElement,
-  type CircleElement as CircleElementType,
-} from "./circle-element";
+export { CircleElement } from "./circle-element";

--- a/src/converter/elements/svg/ellipse/ellipse-element/index.ts
+++ b/src/converter/elements/svg/ellipse/ellipse-element/index.ts
@@ -1,4 +1,1 @@
-export {
-  EllipseElement,
-  type EllipseElement as EllipseElementType,
-} from "./ellipse-element";
+export { EllipseElement } from "./ellipse-element";

--- a/src/converter/elements/svg/index.ts
+++ b/src/converter/elements/svg/index.ts
@@ -10,6 +10,7 @@ export { SvgPaintUtils } from "./utils/svg-paint-utils";
 export {
   SvgCoordinateUtils,
   type BoundingBox,
+  type Point,
 } from "./utils/svg-coordinate-utils";
 
 // 基本図形要素
@@ -28,3 +29,10 @@ export type { EllipseAttributes } from "./ellipse";
 // パス要素
 export { PathElement, PathParser, PathCommand } from "./path";
 export type { PathAttributes, PathCommandType } from "./path";
+
+// ポリゴン・ポリライン要素
+export { PolygonElement } from "./polygon";
+export type { PolygonAttributes } from "./polygon";
+
+export { PolylineElement } from "./polyline";
+export type { PolylineAttributes } from "./polyline";

--- a/src/converter/elements/svg/line/line-element/index.ts
+++ b/src/converter/elements/svg/line/line-element/index.ts
@@ -1,4 +1,1 @@
-export {
-  LineElement,
-  type LineElement as LineElementType,
-} from "./line-element";
+export { LineElement } from "./line-element";

--- a/src/converter/elements/svg/path/index.ts
+++ b/src/converter/elements/svg/path/index.ts
@@ -1,6 +1,5 @@
 export type { PathAttributes } from "./path-attributes";
 export { PathElement } from "./path-element";
-export type { PathElementType } from "./path-element";
 export {
   PathCommand,
   PathParser,

--- a/src/converter/elements/svg/path/path-element/index.ts
+++ b/src/converter/elements/svg/path/path-element/index.ts
@@ -1,2 +1,1 @@
 export { PathElement } from "./path-element";
-export type { PathElement as PathElementType } from "./path-element";

--- a/src/converter/elements/svg/polygon/index.ts
+++ b/src/converter/elements/svg/polygon/index.ts
@@ -1,0 +1,2 @@
+export { PolygonElement } from "./polygon-element";
+export type { PolygonAttributes } from "./polygon-attributes";

--- a/src/converter/elements/svg/polygon/polygon-attributes/index.ts
+++ b/src/converter/elements/svg/polygon/polygon-attributes/index.ts
@@ -1,0 +1,1 @@
+export type { PolygonAttributes } from "./polygon-attributes";

--- a/src/converter/elements/svg/polygon/polygon-attributes/polygon-attributes.ts
+++ b/src/converter/elements/svg/polygon/polygon-attributes/polygon-attributes.ts
@@ -1,0 +1,9 @@
+import type { SvgBaseAttributes } from "../../svg-attributes";
+
+/**
+ * SVG polygon要素の属性
+ */
+export interface PolygonAttributes extends SvgBaseAttributes {
+  /** 多角形の頂点座標リスト（例: "100,10 40,198 190,78"） */
+  points?: string;
+}

--- a/src/converter/elements/svg/polygon/polygon-element/__tests__/polygon-element.factory.test.ts
+++ b/src/converter/elements/svg/polygon/polygon-element/__tests__/polygon-element.factory.test.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "vitest";
+import { PolygonElement } from "../polygon-element";
+
+// PolygonElement.create
+test("PolygonElement.create - 引数なし - デフォルト属性でpolygon要素を作成する", () => {
+  // Arrange & Act
+  const element = PolygonElement.create();
+
+  // Assert
+  expect(element.type).toBe("element");
+  expect(element.tagName).toBe("polygon");
+  expect(element.attributes).toBeDefined();
+});
+
+test("PolygonElement.create - points属性を指定 - pointsが設定されたpolygon要素を作成する", () => {
+  // Arrange & Act
+  const element = PolygonElement.create({
+    points: "100,10 40,198 190,78",
+  });
+
+  // Assert
+  expect(element.attributes.points).toBe("100,10 40,198 190,78");
+});
+
+test("PolygonElement.create - fill属性を指定 - fillが設定されたpolygon要素を作成する", () => {
+  // Arrange & Act
+  const element = PolygonElement.create({
+    points: "100,10 40,198 190,78",
+    fill: "#ff0000",
+  });
+
+  // Assert
+  expect(element.attributes.fill).toBe("#ff0000");
+});
+
+test("PolygonElement.create - stroke属性を指定 - strokeが設定されたpolygon要素を作成する", () => {
+  // Arrange & Act
+  const element = PolygonElement.create({
+    points: "100,10 40,198 190,78",
+    stroke: "#0000ff",
+    "stroke-width": 2,
+  });
+
+  // Assert
+  expect(element.attributes.stroke).toBe("#0000ff");
+  expect(element.attributes["stroke-width"]).toBe(2);
+});

--- a/src/converter/elements/svg/polygon/polygon-element/__tests__/polygon-element.mapToFigma.test.ts
+++ b/src/converter/elements/svg/polygon/polygon-element/__tests__/polygon-element.mapToFigma.test.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "vitest";
+import { PolygonElement } from "../polygon-element";
+
+// PolygonElement.mapToFigma
+test("PolygonElement.mapToFigma - polygon要素 - FigmaNodeConfigを返す", () => {
+  // Arrange
+  const node = {
+    type: "element",
+    tagName: "polygon",
+    attributes: { points: "100,10 40,198 190,78" },
+  };
+
+  // Act
+  const result = PolygonElement.mapToFigma(node);
+
+  // Assert
+  expect(result).not.toBeNull();
+  expect(result?.type).toBe("FRAME");
+  expect(result?.name).toBe("polygon");
+});
+
+test("PolygonElement.mapToFigma - 異なるタグ名 - nullを返す", () => {
+  // Arrange
+  const node = {
+    type: "element",
+    tagName: "polyline",
+    attributes: { points: "100,10 40,198 190,78" },
+  };
+
+  // Act
+  const result = PolygonElement.mapToFigma(node);
+
+  // Assert
+  expect(result).toBeNull();
+});
+
+test("PolygonElement.mapToFigma - null - nullを返す", () => {
+  // Arrange & Act
+  const result = PolygonElement.mapToFigma(null);
+
+  // Assert
+  expect(result).toBeNull();
+});
+
+test("PolygonElement.mapToFigma - fill属性付き - 正しくマッピングする", () => {
+  // Arrange
+  const node = {
+    type: "element",
+    tagName: "polygon",
+    attributes: {
+      points: "100,10 40,198 190,78",
+      fill: "#ff0000",
+    },
+  };
+
+  // Act
+  const result = PolygonElement.mapToFigma(node);
+
+  // Assert
+  expect(result).not.toBeNull();
+  expect(result?.fills).toBeDefined();
+});

--- a/src/converter/elements/svg/polygon/polygon-element/__tests__/polygon-element.toFigmaNode.test.ts
+++ b/src/converter/elements/svg/polygon/polygon-element/__tests__/polygon-element.toFigmaNode.test.ts
@@ -1,0 +1,95 @@
+import { test, expect } from "vitest";
+import { PolygonElement } from "../polygon-element";
+
+// PolygonElement.toFigmaNode
+test("PolygonElement.toFigmaNode - 三角形 - FRAMEノードを返す", () => {
+  // Arrange
+  const element = PolygonElement.create({
+    points: "100,10 40,198 190,78",
+  });
+
+  // Act
+  const result = PolygonElement.toFigmaNode(element);
+
+  // Assert
+  expect(result.type).toBe("FRAME");
+  expect(result.name).toBe("polygon");
+});
+
+test("PolygonElement.toFigmaNode - 三角形 - 正しい境界ボックスを計算する", () => {
+  // Arrange
+  const element = PolygonElement.create({
+    points: "100,10 40,198 190,78",
+  });
+
+  // Act
+  const result = PolygonElement.toFigmaNode(element);
+
+  // Assert
+  expect(result.x).toBe(40);
+  expect(result.y).toBe(10);
+  expect(result.width).toBe(150);
+  expect(result.height).toBe(188);
+});
+
+test("PolygonElement.toFigmaNode - fill属性あり - fillsが設定される", () => {
+  // Arrange
+  const element = PolygonElement.create({
+    points: "100,10 40,198 190,78",
+    fill: "#ff0000",
+  });
+
+  // Act
+  const result = PolygonElement.toFigmaNode(element);
+
+  // Assert
+  expect(result.fills).toBeDefined();
+  expect(result.fills?.length).toBeGreaterThan(0);
+});
+
+test("PolygonElement.toFigmaNode - stroke属性あり - strokesが設定される", () => {
+  // Arrange
+  const element = PolygonElement.create({
+    points: "100,10 40,198 190,78",
+    stroke: "#0000ff",
+    "stroke-width": 3,
+  });
+
+  // Act
+  const result = PolygonElement.toFigmaNode(element);
+
+  // Assert
+  expect(result.strokes).toBeDefined();
+  expect(result.strokes?.length).toBeGreaterThan(0);
+  expect(result.strokeWeight).toBe(3);
+});
+
+test("PolygonElement.toFigmaNode - points未指定 - ゼロサイズのノードを返す", () => {
+  // Arrange
+  const element = PolygonElement.create({});
+
+  // Act
+  const result = PolygonElement.toFigmaNode(element);
+
+  // Assert
+  expect(result.x).toBe(0);
+  expect(result.y).toBe(0);
+  expect(result.width).toBe(0);
+  expect(result.height).toBe(0);
+});
+
+test("PolygonElement.toFigmaNode - 五角形 - 正しい境界ボックスを計算する", () => {
+  // Arrange (星形の五角形)
+  const element = PolygonElement.create({
+    points: "100,10 40,198 190,78 10,78 160,198",
+  });
+
+  // Act
+  const result = PolygonElement.toFigmaNode(element);
+
+  // Assert
+  expect(result.x).toBe(10);
+  expect(result.y).toBe(10);
+  expect(result.width).toBe(180);
+  expect(result.height).toBe(188);
+});

--- a/src/converter/elements/svg/polygon/polygon-element/__tests__/polygon-element.typeguards.test.ts
+++ b/src/converter/elements/svg/polygon/polygon-element/__tests__/polygon-element.typeguards.test.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "vitest";
+import { PolygonElement } from "../polygon-element";
+
+// PolygonElement.isPolygonElement
+test("PolygonElement.isPolygonElement - polygon要素 - trueを返す", () => {
+  // Arrange
+  const element = {
+    type: "element",
+    tagName: "polygon",
+    attributes: { points: "100,10 40,198 190,78" },
+  };
+
+  // Act
+  const result = PolygonElement.isPolygonElement(element);
+
+  // Assert
+  expect(result).toBe(true);
+});
+
+test("PolygonElement.isPolygonElement - 異なるタグ名 - falseを返す", () => {
+  // Arrange
+  const element = {
+    type: "element",
+    tagName: "polyline",
+    attributes: { points: "100,10 40,198 190,78" },
+  };
+
+  // Act
+  const result = PolygonElement.isPolygonElement(element);
+
+  // Assert
+  expect(result).toBe(false);
+});
+
+test("PolygonElement.isPolygonElement - 異なるtype - falseを返す", () => {
+  // Arrange
+  const element = {
+    type: "text",
+    tagName: "polygon",
+    attributes: {},
+  };
+
+  // Act
+  const result = PolygonElement.isPolygonElement(element);
+
+  // Assert
+  expect(result).toBe(false);
+});
+
+test("PolygonElement.isPolygonElement - null - falseを返す", () => {
+  // Arrange & Act
+  const result = PolygonElement.isPolygonElement(null);
+
+  // Assert
+  expect(result).toBe(false);
+});
+
+test("PolygonElement.isPolygonElement - undefined - falseを返す", () => {
+  // Arrange & Act
+  const result = PolygonElement.isPolygonElement(undefined);
+
+  // Assert
+  expect(result).toBe(false);
+});
+
+test("PolygonElement.isPolygonElement - プリミティブ値 - falseを返す", () => {
+  // Arrange & Act & Assert
+  expect(PolygonElement.isPolygonElement("polygon")).toBe(false);
+  expect(PolygonElement.isPolygonElement(123)).toBe(false);
+  expect(PolygonElement.isPolygonElement(true)).toBe(false);
+});

--- a/src/converter/elements/svg/polygon/polygon-element/index.ts
+++ b/src/converter/elements/svg/polygon/polygon-element/index.ts
@@ -1,0 +1,1 @@
+export { PolygonElement } from "./polygon-element";

--- a/src/converter/elements/svg/polygon/polygon-element/polygon-element.ts
+++ b/src/converter/elements/svg/polygon/polygon-element/polygon-element.ts
@@ -1,0 +1,93 @@
+import type { FigmaNodeConfig } from "../../../../models/figma-node";
+import { FigmaNode } from "../../../../models/figma-node";
+import { mapToFigmaWith } from "../../../../utils/element-utils";
+import type { PolygonAttributes } from "../polygon-attributes";
+import { SvgCoordinateUtils } from "../../utils/svg-coordinate-utils";
+import { SvgPaintUtils } from "../../utils/svg-paint-utils";
+
+/**
+ * SVG polygon要素の型定義
+ */
+export interface PolygonElement {
+  type: "element";
+  tagName: "polygon";
+  attributes: PolygonAttributes;
+  children?: never;
+}
+
+/**
+ * PolygonElementコンパニオンオブジェクト
+ */
+export const PolygonElement = {
+  /**
+   * 型ガード
+   */
+  isPolygonElement(node: unknown): node is PolygonElement {
+    return (
+      typeof node === "object" &&
+      node !== null &&
+      "type" in node &&
+      "tagName" in node &&
+      node.type === "element" &&
+      node.tagName === "polygon"
+    );
+  },
+
+  /**
+   * ファクトリーメソッド
+   */
+  create(attributes: Partial<PolygonAttributes> = {}): PolygonElement {
+    return {
+      type: "element",
+      tagName: "polygon",
+      attributes: attributes as PolygonAttributes,
+    };
+  },
+
+  /**
+   * points属性を取得
+   */
+  getPoints(element: PolygonElement): string {
+    return element.attributes.points ?? "";
+  },
+
+  /**
+   * PolygonElementをFigmaのFRAMEノードに変換
+   *
+   * SVG polygon要素は閉じた多角形を表現します。
+   * FigmaのVECTORノードは複雑なvectorNetworkの設定が必要なため、
+   * 境界ボックスを計算してFRAMEノードで表現する設計を採用しています。
+   *
+   * @param element 変換するPolygon要素
+   * @returns FigmaノードConfig（FRAMEタイプ）
+   */
+  toFigmaNode(element: PolygonElement): FigmaNodeConfig {
+    const pointsString = this.getPoints(element);
+    const points = SvgCoordinateUtils.parsePoints(pointsString);
+    const bounds = SvgCoordinateUtils.calculatePointsBounds(points);
+
+    const config = FigmaNode.createFrame("polygon");
+
+    config.x = bounds.x;
+    config.y = bounds.y;
+    config.width = bounds.width;
+    config.height = bounds.height;
+
+    SvgPaintUtils.applyPaintToNode(config, element.attributes);
+
+    return config;
+  },
+
+  /**
+   * マッピング関数
+   */
+  mapToFigma(node: unknown): FigmaNodeConfig | null {
+    return mapToFigmaWith(
+      node,
+      "polygon",
+      this.isPolygonElement,
+      this.create,
+      (element) => this.toFigmaNode(element),
+    );
+  },
+};

--- a/src/converter/elements/svg/polyline/index.ts
+++ b/src/converter/elements/svg/polyline/index.ts
@@ -1,0 +1,2 @@
+export { PolylineElement } from "./polyline-element";
+export type { PolylineAttributes } from "./polyline-attributes";

--- a/src/converter/elements/svg/polyline/polyline-attributes/index.ts
+++ b/src/converter/elements/svg/polyline/polyline-attributes/index.ts
@@ -1,0 +1,1 @@
+export type { PolylineAttributes } from "./polyline-attributes";

--- a/src/converter/elements/svg/polyline/polyline-attributes/polyline-attributes.ts
+++ b/src/converter/elements/svg/polyline/polyline-attributes/polyline-attributes.ts
@@ -1,0 +1,9 @@
+import type { SvgBaseAttributes } from "../../svg-attributes";
+
+/**
+ * SVG polyline要素の属性
+ */
+export interface PolylineAttributes extends SvgBaseAttributes {
+  /** 折れ線の頂点座標リスト（例: "0,40 40,40 40,80 80,80"） */
+  points?: string;
+}

--- a/src/converter/elements/svg/polyline/polyline-element/__tests__/polyline-element.factory.test.ts
+++ b/src/converter/elements/svg/polyline/polyline-element/__tests__/polyline-element.factory.test.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "vitest";
+import { PolylineElement } from "../polyline-element";
+
+// PolylineElement.create
+test("PolylineElement.create - 引数なし - デフォルト属性でpolyline要素を作成する", () => {
+  // Arrange & Act
+  const element = PolylineElement.create();
+
+  // Assert
+  expect(element.type).toBe("element");
+  expect(element.tagName).toBe("polyline");
+  expect(element.attributes).toBeDefined();
+});
+
+test("PolylineElement.create - points属性を指定 - pointsが設定されたpolyline要素を作成する", () => {
+  // Arrange & Act
+  const element = PolylineElement.create({
+    points: "0,40 40,40 40,80 80,80",
+  });
+
+  // Assert
+  expect(element.attributes.points).toBe("0,40 40,40 40,80 80,80");
+});
+
+test("PolylineElement.create - fill属性を指定 - fillが設定されたpolyline要素を作成する", () => {
+  // Arrange & Act
+  const element = PolylineElement.create({
+    points: "0,40 40,40 40,80 80,80",
+    fill: "none",
+  });
+
+  // Assert
+  expect(element.attributes.fill).toBe("none");
+});
+
+test("PolylineElement.create - stroke属性を指定 - strokeが設定されたpolyline要素を作成する", () => {
+  // Arrange & Act
+  const element = PolylineElement.create({
+    points: "0,40 40,40 40,80 80,80",
+    stroke: "#0000ff",
+    "stroke-width": 2,
+  });
+
+  // Assert
+  expect(element.attributes.stroke).toBe("#0000ff");
+  expect(element.attributes["stroke-width"]).toBe(2);
+});

--- a/src/converter/elements/svg/polyline/polyline-element/__tests__/polyline-element.mapToFigma.test.ts
+++ b/src/converter/elements/svg/polyline/polyline-element/__tests__/polyline-element.mapToFigma.test.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "vitest";
+import { PolylineElement } from "../polyline-element";
+
+// PolylineElement.mapToFigma
+test("PolylineElement.mapToFigma - polyline要素 - FigmaNodeConfigを返す", () => {
+  // Arrange
+  const node = {
+    type: "element",
+    tagName: "polyline",
+    attributes: { points: "0,40 40,40 40,80 80,80" },
+  };
+
+  // Act
+  const result = PolylineElement.mapToFigma(node);
+
+  // Assert
+  expect(result).not.toBeNull();
+  expect(result?.type).toBe("FRAME");
+  expect(result?.name).toBe("polyline");
+});
+
+test("PolylineElement.mapToFigma - 異なるタグ名 - nullを返す", () => {
+  // Arrange
+  const node = {
+    type: "element",
+    tagName: "polygon",
+    attributes: { points: "0,40 40,40 40,80 80,80" },
+  };
+
+  // Act
+  const result = PolylineElement.mapToFigma(node);
+
+  // Assert
+  expect(result).toBeNull();
+});
+
+test("PolylineElement.mapToFigma - null - nullを返す", () => {
+  // Arrange & Act
+  const result = PolylineElement.mapToFigma(null);
+
+  // Assert
+  expect(result).toBeNull();
+});
+
+test("PolylineElement.mapToFigma - stroke属性付き - 正しくマッピングする", () => {
+  // Arrange
+  const node = {
+    type: "element",
+    tagName: "polyline",
+    attributes: {
+      points: "0,40 40,40 40,80 80,80",
+      stroke: "#0000ff",
+      "stroke-width": 2,
+    },
+  };
+
+  // Act
+  const result = PolylineElement.mapToFigma(node);
+
+  // Assert
+  expect(result).not.toBeNull();
+  expect(result?.strokes).toBeDefined();
+});

--- a/src/converter/elements/svg/polyline/polyline-element/__tests__/polyline-element.toFigmaNode.test.ts
+++ b/src/converter/elements/svg/polyline/polyline-element/__tests__/polyline-element.toFigmaNode.test.ts
@@ -1,0 +1,95 @@
+import { test, expect } from "vitest";
+import { PolylineElement } from "../polyline-element";
+
+// PolylineElement.toFigmaNode
+test("PolylineElement.toFigmaNode - 階段状の折れ線 - FRAMEノードを返す", () => {
+  // Arrange
+  const element = PolylineElement.create({
+    points: "0,40 40,40 40,80 80,80",
+  });
+
+  // Act
+  const result = PolylineElement.toFigmaNode(element);
+
+  // Assert
+  expect(result.type).toBe("FRAME");
+  expect(result.name).toBe("polyline");
+});
+
+test("PolylineElement.toFigmaNode - 階段状の折れ線 - 正しい境界ボックスを計算する", () => {
+  // Arrange
+  const element = PolylineElement.create({
+    points: "0,40 40,40 40,80 80,80",
+  });
+
+  // Act
+  const result = PolylineElement.toFigmaNode(element);
+
+  // Assert
+  expect(result.x).toBe(0);
+  expect(result.y).toBe(40);
+  expect(result.width).toBe(80);
+  expect(result.height).toBe(40);
+});
+
+test("PolylineElement.toFigmaNode - stroke属性あり - strokesが設定される", () => {
+  // Arrange
+  const element = PolylineElement.create({
+    points: "0,40 40,40 40,80 80,80",
+    stroke: "#0000ff",
+    "stroke-width": 3,
+  });
+
+  // Act
+  const result = PolylineElement.toFigmaNode(element);
+
+  // Assert
+  expect(result.strokes).toBeDefined();
+  expect(result.strokes?.length).toBeGreaterThan(0);
+  expect(result.strokeWeight).toBe(3);
+});
+
+test("PolylineElement.toFigmaNode - fill=none - fillsが空になる", () => {
+  // Arrange
+  const element = PolylineElement.create({
+    points: "0,40 40,40 40,80 80,80",
+    fill: "none",
+    stroke: "#000000",
+  });
+
+  // Act
+  const result = PolylineElement.toFigmaNode(element);
+
+  // Assert
+  expect(result.fills).toEqual([]);
+});
+
+test("PolylineElement.toFigmaNode - points未指定 - ゼロサイズのノードを返す", () => {
+  // Arrange
+  const element = PolylineElement.create({});
+
+  // Act
+  const result = PolylineElement.toFigmaNode(element);
+
+  // Assert
+  expect(result.x).toBe(0);
+  expect(result.y).toBe(0);
+  expect(result.width).toBe(0);
+  expect(result.height).toBe(0);
+});
+
+test("PolylineElement.toFigmaNode - ジグザグ線 - 正しい境界ボックスを計算する", () => {
+  // Arrange
+  const element = PolylineElement.create({
+    points: "0,0 20,40 40,0 60,40 80,0",
+  });
+
+  // Act
+  const result = PolylineElement.toFigmaNode(element);
+
+  // Assert
+  expect(result.x).toBe(0);
+  expect(result.y).toBe(0);
+  expect(result.width).toBe(80);
+  expect(result.height).toBe(40);
+});

--- a/src/converter/elements/svg/polyline/polyline-element/__tests__/polyline-element.typeguards.test.ts
+++ b/src/converter/elements/svg/polyline/polyline-element/__tests__/polyline-element.typeguards.test.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "vitest";
+import { PolylineElement } from "../polyline-element";
+
+// PolylineElement.isPolylineElement
+test("PolylineElement.isPolylineElement - polyline要素 - trueを返す", () => {
+  // Arrange
+  const element = {
+    type: "element",
+    tagName: "polyline",
+    attributes: { points: "0,40 40,40 40,80 80,80" },
+  };
+
+  // Act
+  const result = PolylineElement.isPolylineElement(element);
+
+  // Assert
+  expect(result).toBe(true);
+});
+
+test("PolylineElement.isPolylineElement - 異なるタグ名 - falseを返す", () => {
+  // Arrange
+  const element = {
+    type: "element",
+    tagName: "polygon",
+    attributes: { points: "0,40 40,40 40,80 80,80" },
+  };
+
+  // Act
+  const result = PolylineElement.isPolylineElement(element);
+
+  // Assert
+  expect(result).toBe(false);
+});
+
+test("PolylineElement.isPolylineElement - 異なるtype - falseを返す", () => {
+  // Arrange
+  const element = {
+    type: "text",
+    tagName: "polyline",
+    attributes: {},
+  };
+
+  // Act
+  const result = PolylineElement.isPolylineElement(element);
+
+  // Assert
+  expect(result).toBe(false);
+});
+
+test("PolylineElement.isPolylineElement - null - falseを返す", () => {
+  // Arrange & Act
+  const result = PolylineElement.isPolylineElement(null);
+
+  // Assert
+  expect(result).toBe(false);
+});
+
+test("PolylineElement.isPolylineElement - undefined - falseを返す", () => {
+  // Arrange & Act
+  const result = PolylineElement.isPolylineElement(undefined);
+
+  // Assert
+  expect(result).toBe(false);
+});
+
+test("PolylineElement.isPolylineElement - プリミティブ値 - falseを返す", () => {
+  // Arrange & Act & Assert
+  expect(PolylineElement.isPolylineElement("polyline")).toBe(false);
+  expect(PolylineElement.isPolylineElement(123)).toBe(false);
+  expect(PolylineElement.isPolylineElement(true)).toBe(false);
+});

--- a/src/converter/elements/svg/polyline/polyline-element/index.ts
+++ b/src/converter/elements/svg/polyline/polyline-element/index.ts
@@ -1,0 +1,1 @@
+export { PolylineElement } from "./polyline-element";

--- a/src/converter/elements/svg/polyline/polyline-element/polyline-element.ts
+++ b/src/converter/elements/svg/polyline/polyline-element/polyline-element.ts
@@ -1,0 +1,93 @@
+import type { FigmaNodeConfig } from "../../../../models/figma-node";
+import { FigmaNode } from "../../../../models/figma-node";
+import { mapToFigmaWith } from "../../../../utils/element-utils";
+import type { PolylineAttributes } from "../polyline-attributes";
+import { SvgCoordinateUtils } from "../../utils/svg-coordinate-utils";
+import { SvgPaintUtils } from "../../utils/svg-paint-utils";
+
+/**
+ * SVG polyline要素の型定義
+ */
+export interface PolylineElement {
+  type: "element";
+  tagName: "polyline";
+  attributes: PolylineAttributes;
+  children?: never;
+}
+
+/**
+ * PolylineElementコンパニオンオブジェクト
+ */
+export const PolylineElement = {
+  /**
+   * 型ガード
+   */
+  isPolylineElement(node: unknown): node is PolylineElement {
+    return (
+      typeof node === "object" &&
+      node !== null &&
+      "type" in node &&
+      "tagName" in node &&
+      node.type === "element" &&
+      node.tagName === "polyline"
+    );
+  },
+
+  /**
+   * ファクトリーメソッド
+   */
+  create(attributes: Partial<PolylineAttributes> = {}): PolylineElement {
+    return {
+      type: "element",
+      tagName: "polyline",
+      attributes: attributes as PolylineAttributes,
+    };
+  },
+
+  /**
+   * points属性を取得
+   */
+  getPoints(element: PolylineElement): string {
+    return element.attributes.points ?? "";
+  },
+
+  /**
+   * PolylineElementをFigmaのFRAMEノードに変換
+   *
+   * SVG polyline要素は開いた折れ線を表現します（最初と最後の点は接続されない）。
+   * FigmaのVECTORノードは複雑なvectorNetworkの設定が必要なため、
+   * 境界ボックスを計算してFRAMEノードで表現する設計を採用しています。
+   *
+   * @param element 変換するPolyline要素
+   * @returns FigmaノードConfig（FRAMEタイプ）
+   */
+  toFigmaNode(element: PolylineElement): FigmaNodeConfig {
+    const pointsString = this.getPoints(element);
+    const points = SvgCoordinateUtils.parsePoints(pointsString);
+    const bounds = SvgCoordinateUtils.calculatePointsBounds(points);
+
+    const config = FigmaNode.createFrame("polyline");
+
+    config.x = bounds.x;
+    config.y = bounds.y;
+    config.width = bounds.width;
+    config.height = bounds.height;
+
+    SvgPaintUtils.applyPaintToNode(config, element.attributes);
+
+    return config;
+  },
+
+  /**
+   * マッピング関数
+   */
+  mapToFigma(node: unknown): FigmaNodeConfig | null {
+    return mapToFigmaWith(
+      node,
+      "polyline",
+      this.isPolylineElement,
+      this.create,
+      (element) => this.toFigmaNode(element),
+    );
+  },
+};

--- a/src/converter/elements/svg/rect/rect-element/index.ts
+++ b/src/converter/elements/svg/rect/rect-element/index.ts
@@ -1,4 +1,1 @@
-export {
-  RectElement,
-  type RectElement as RectElementType,
-} from "./rect-element";
+export { RectElement } from "./rect-element";

--- a/src/converter/elements/svg/utils/__tests__/svg-coordinate-utils.test.ts
+++ b/src/converter/elements/svg/utils/__tests__/svg-coordinate-utils.test.ts
@@ -157,3 +157,150 @@ test("SvgCoordinateUtils.calculateRectBounds - 座標とサイズを指定 - 境
   expect(bounds.width).toBe(100);
   expect(bounds.height).toBe(50);
 });
+
+// SvgCoordinateUtils.parsePoints
+test("SvgCoordinateUtils.parsePoints - カンマ区切りの座標ペア - 点の配列を返す", () => {
+  // Arrange & Act
+  const points = SvgCoordinateUtils.parsePoints("100,10 40,198 190,78");
+
+  // Assert
+  expect(points).toEqual([
+    { x: 100, y: 10 },
+    { x: 40, y: 198 },
+    { x: 190, y: 78 },
+  ]);
+});
+
+test("SvgCoordinateUtils.parsePoints - スペースのみの区切り - 点の配列を返す", () => {
+  // Arrange & Act
+  const points = SvgCoordinateUtils.parsePoints("100 10 40 198 190 78");
+
+  // Assert
+  expect(points).toEqual([
+    { x: 100, y: 10 },
+    { x: 40, y: 198 },
+    { x: 190, y: 78 },
+  ]);
+});
+
+test("SvgCoordinateUtils.parsePoints - 負の値を含む座標 - 正しくパースする", () => {
+  // Arrange & Act
+  const points = SvgCoordinateUtils.parsePoints("-10,20 30,-40 -50,-60");
+
+  // Assert
+  expect(points).toEqual([
+    { x: -10, y: 20 },
+    { x: 30, y: -40 },
+    { x: -50, y: -60 },
+  ]);
+});
+
+test("SvgCoordinateUtils.parsePoints - 小数点を含む座標 - 正しくパースする", () => {
+  // Arrange & Act
+  const points = SvgCoordinateUtils.parsePoints("10.5,20.3 30.7,40.9");
+
+  // Assert
+  expect(points).toEqual([
+    { x: 10.5, y: 20.3 },
+    { x: 30.7, y: 40.9 },
+  ]);
+});
+
+test("SvgCoordinateUtils.parsePoints - 空文字列 - 空配列を返す", () => {
+  // Arrange & Act
+  const points = SvgCoordinateUtils.parsePoints("");
+
+  // Assert
+  expect(points).toEqual([]);
+});
+
+test("SvgCoordinateUtils.parsePoints - undefined - 空配列を返す", () => {
+  // Arrange & Act
+  const points = SvgCoordinateUtils.parsePoints(undefined);
+
+  // Assert
+  expect(points).toEqual([]);
+});
+
+test("SvgCoordinateUtils.parsePoints - 奇数個の数値 - 完全なペアのみ返す", () => {
+  // Arrange & Act
+  const points = SvgCoordinateUtils.parsePoints("10,20 30,40 50");
+
+  // Assert
+  expect(points).toEqual([
+    { x: 10, y: 20 },
+    { x: 30, y: 40 },
+  ]);
+});
+
+test("SvgCoordinateUtils.parsePoints - 余分な空白を含む - 正しくパースする", () => {
+  // Arrange & Act
+  const points = SvgCoordinateUtils.parsePoints("  10,20   30,40  ");
+
+  // Assert
+  expect(points).toEqual([
+    { x: 10, y: 20 },
+    { x: 30, y: 40 },
+  ]);
+});
+
+// SvgCoordinateUtils.calculatePointsBounds
+test("SvgCoordinateUtils.calculatePointsBounds - 複数の点 - 境界ボックスを計算する", () => {
+  // Arrange
+  const points = [
+    { x: 100, y: 10 },
+    { x: 40, y: 198 },
+    { x: 190, y: 78 },
+  ];
+
+  // Act
+  const bounds = SvgCoordinateUtils.calculatePointsBounds(points);
+
+  // Assert
+  expect(bounds.x).toBe(40);
+  expect(bounds.y).toBe(10);
+  expect(bounds.width).toBe(150);
+  expect(bounds.height).toBe(188);
+});
+
+test("SvgCoordinateUtils.calculatePointsBounds - 空の配列 - ゼロの境界ボックスを返す", () => {
+  // Arrange & Act
+  const bounds = SvgCoordinateUtils.calculatePointsBounds([]);
+
+  // Assert
+  expect(bounds.x).toBe(0);
+  expect(bounds.y).toBe(0);
+  expect(bounds.width).toBe(0);
+  expect(bounds.height).toBe(0);
+});
+
+test("SvgCoordinateUtils.calculatePointsBounds - 単一の点 - 幅と高さ0の境界ボックスを返す", () => {
+  // Arrange
+  const points = [{ x: 50, y: 30 }];
+
+  // Act
+  const bounds = SvgCoordinateUtils.calculatePointsBounds(points);
+
+  // Assert
+  expect(bounds.x).toBe(50);
+  expect(bounds.y).toBe(30);
+  expect(bounds.width).toBe(0);
+  expect(bounds.height).toBe(0);
+});
+
+test("SvgCoordinateUtils.calculatePointsBounds - 負の座標を含む - 正しい境界ボックスを計算する", () => {
+  // Arrange
+  const points = [
+    { x: -10, y: -20 },
+    { x: 30, y: 40 },
+  ];
+
+  // Act
+  const bounds = SvgCoordinateUtils.calculatePointsBounds(points);
+
+  // Assert
+  expect(bounds.x).toBe(-10);
+  expect(bounds.y).toBe(-20);
+  expect(bounds.width).toBe(40);
+  expect(bounds.height).toBe(60);
+});

--- a/src/converter/elements/svg/utils/index.ts
+++ b/src/converter/elements/svg/utils/index.ts
@@ -1,2 +1,6 @@
 export { SvgPaintUtils } from "./svg-paint-utils";
-export { SvgCoordinateUtils, type BoundingBox } from "./svg-coordinate-utils";
+export {
+  SvgCoordinateUtils,
+  type BoundingBox,
+  type Point,
+} from "./svg-coordinate-utils";

--- a/src/converter/elements/svg/utils/svg-coordinate-utils.ts
+++ b/src/converter/elements/svg/utils/svg-coordinate-utils.ts
@@ -11,6 +11,14 @@ export interface BoundingBox {
   height: number;
 }
 
+/**
+ * 点座標の型
+ */
+export interface Point {
+  x: number;
+  y: number;
+}
+
 export const SvgCoordinateUtils = {
   /**
    * 属性値を数値にパースする
@@ -119,6 +127,64 @@ export const SvgCoordinateUtils = {
       y,
       width,
       height,
+    };
+  },
+
+  /**
+   * SVG points属性をパースして点の配列を返す
+   *
+   * SVG仕様に従い、カンマまたはスペースで区切られた座標ペアを解析します。
+   * 形式: "x1,y1 x2,y2 ..." または "x1 y1 x2 y2 ..."
+   *
+   * @param points points属性値
+   * @returns 点の配列
+   */
+  parsePoints(points: string | undefined): Point[] {
+    if (!points || points.trim() === "") {
+      return [];
+    }
+
+    const numbers = points
+      .trim()
+      .split(/[\s,]+/)
+      .map((s) => parseFloat(s))
+      .filter((n) => !isNaN(n));
+
+    const result: Point[] = [];
+    for (let i = 0; i + 1 < numbers.length; i += 2) {
+      result.push({ x: numbers[i], y: numbers[i + 1] });
+    }
+
+    return result;
+  },
+
+  /**
+   * 点の配列から境界ボックスを計算
+   * @param points 点の配列
+   * @returns 境界ボックス
+   */
+  calculatePointsBounds(points: Point[]): BoundingBox {
+    if (points.length === 0) {
+      return { x: 0, y: 0, width: 0, height: 0 };
+    }
+
+    let minX = points[0].x;
+    let minY = points[0].y;
+    let maxX = points[0].x;
+    let maxY = points[0].y;
+
+    for (const point of points) {
+      minX = Math.min(minX, point.x);
+      minY = Math.min(minY, point.y);
+      maxX = Math.max(maxX, point.x);
+      maxY = Math.max(maxY, point.y);
+    }
+
+    return {
+      x: minX,
+      y: minY,
+      width: maxX - minX,
+      height: maxY - minY,
     };
   },
 };


### PR DESCRIPTION
## 概要

SVGのpolygon（多角形）とpolyline（折れ線）要素のFigma変換機能を実装しました。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)
- [x] ♻️ リファクタリング (Refactoring)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `PolygonElement` コンパニオンオブジェクト（型ガード、ファクトリ、toFigmaNode、mapToFigma）
- `PolylineElement` コンパニオンオブジェクト（型ガード、ファクトリ、toFigmaNode、mapToFigma）
- `SvgCoordinateUtils.parsePoints()` - points属性を座標配列にパース
- `SvgCoordinateUtils.calculatePointsBounds()` - 座標配列から境界ボックスを計算
- `Point` 型のエクスポート
- polygon/polyline要素の統合テスト

#### 変更されたファイル

- `src/converter/elements/svg/utils/svg-coordinate-utils.ts` - parsePoints, calculatePointsBounds追加
- `src/converter/elements/svg/utils/index.ts` - Point型エクスポート追加
- `src/converter/elements/svg/index.ts` - PolygonElement, PolylineElementエクスポート追加
- `src/converter/elements/svg/__tests__/svg-shapes.integration.test.ts` - 統合テスト追加
- 既存SVG要素のindex.ts - 不要なXXXElementTypeエイリアスを削除

#### 削除されたファイル・機能

- なし

## 📋 関連 Issue

Closes #133

## 🧪 テスト

### テスト実行方法

```bash
npm test -- --run src/converter/elements/svg/
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 統合テスト (Integration tests)

### テスト結果

- 全315テストがパス
- lint、型チェックもパス

## 🔍 レビューポイント

- `parsePoints()`のパース処理（カンマ・スペース区切り、負の値、小数点対応）
- polygon/polylineの違い（閉じた多角形 vs 開いた折れ線）の実装
- コンパニオンオブジェクトパターンのエクスポート形式の統一

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] セルフレビューを実施した
